### PR TITLE
Workspace level message tracking

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,6 +1,7 @@
 LinterView = require './linter-view'
 StatusBarView = require './statusbar-view'
 InlineView = require './inline-view'
+WorkspaceView = require './workspace-view'
 # Public: linter package initialization, sets up the linter for usages by atom
 class LinterInitializer
 
@@ -30,6 +31,9 @@ class LinterInitializer
     showErrorInline:
       type: 'boolean'
       default: false
+    showOnTabAndTreeView:
+      type: 'boolean'
+      default: true
     statusBar:
       type: 'string'
       default: 'Show error of the selected line'
@@ -63,6 +67,7 @@ class LinterInitializer
     @enabled = true
     @statusBarView = new StatusBarView()
     @inlineView = new InlineView()
+    @workspaceView = new WorkspaceView()
 
     # Subscribing to every current and future editor
     @editorSubscription = atom.workspace.observeTextEditors (editor) =>
@@ -77,6 +82,7 @@ class LinterInitializer
     return if editor.linterView?
 
     linterView = new LinterView(editor, statusBarView, inlineView, @linters)
+    linterView.onFileMessages @workspaceView.updateFile.bind(@workspaceView)
     linterView
 
   # Public: deactivate the plugin and unregister all subscriptions

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -4,7 +4,7 @@ temp = require 'temp'
 path = require 'path'
 {log, warn} = require './utils'
 rimraf = require 'rimraf'
-{CompositeDisposable} = require 'event-kit'
+{CompositeDisposable, Emitter} = require 'event-kit'
 
 
 temp.track()
@@ -25,6 +25,7 @@ class LinterView
   # statusBarView - shared StatusBarView between all linters
   # linters - global linter set to utilize for linting
   constructor: (@editor, @statusBarView, @inlineView, @linters = []) ->
+    @emitter = new Emitter
     @subscriptions = new CompositeDisposable
     unless @editor?
       warn "No editor instance on this editor"
@@ -159,7 +160,12 @@ class LinterView
         throw err if err?
 
     @messages = @messages.concat(messages)
+    @emitter.emit 'messages', file: @editor.getPath() , messages: messages
     @display()
+
+  # Public: on messages from linter
+  onFileMessages: (callback) ->
+    @emitter.on('messages', callback)
 
   # Internal: Destroy all markers (and associated decorations)
   destroyMarkers: ->
@@ -204,7 +210,6 @@ class LinterView
       @inlineView.render @messages, @editor
     else
       @inlineView.render [], @editor
-
 
   # Public: remove this view and unregister all it's subscriptions
   remove: ->

--- a/lib/workspace-view.coffee
+++ b/lib/workspace-view.coffee
@@ -1,16 +1,7 @@
-_ = require 'lodash'
-fs = require 'fs'
-temp = require 'temp'
-path = require 'path'
-{log, warn} = require './utils'
-rimraf = require 'rimraf'
 {CompositeDisposable} = require 'event-kit'
 
-
-temp.track()
-
 # Public: The base linter view
-class LinterView
+class WorkspaceView
 
   fileMessages: {}
   views: []
@@ -86,4 +77,4 @@ class LinterView
       @removeFileLevelIndicator(file)
     @subscriptions.dispose()
 
-module.exports = LinterView
+module.exports = WorkspaceView

--- a/lib/workspace-view.coffee
+++ b/lib/workspace-view.coffee
@@ -1,0 +1,95 @@
+_ = require 'lodash'
+fs = require 'fs'
+temp = require 'temp'
+path = require 'path'
+{log, warn} = require './utils'
+rimraf = require 'rimraf'
+{CompositeDisposable, Emitter} = require 'event-kit'
+
+
+temp.track()
+
+# Public: The base linter view
+class LinterView
+
+  fileMessages: {}
+  views: []
+
+  # Pubic: Instantiate the views
+  #
+  # editor - the atom editor view on which to place highlighting and gutter
+  #              annotations
+  # statusBarView - shared StatusBarView between all linters
+  # linters - global linter set to utilize for linting
+  constructor: ->
+    @subscriptions = new CompositeDisposable
+
+    @handleConfigChanges()
+
+  # Internal: register config modifications handlers
+  handleConfigChanges: ->
+    @subscriptions.add atom.config.observe 'linter.showOnTabAndTreeView',
+      (showOnTabAndTreeView) =>
+        @showOnTabAndTreeView = showOnTabAndTreeView
+        @display()
+
+
+    atom.commands.add "atom-text-editor",
+      "linter:lint", => @lint()
+
+  getViews: =>
+    tabsPackage = atom.packages.getActivePackage('tabs')
+    if tabsPackage?
+      @views = @views.concat tabsPackage.requireMainModule()?.tabBarViews
+
+    treeViewPackage = atom.packages.getActivePackage('tree-view')
+    if treeViewPackage?
+      @views.push treeViewPackage.requireMainModule()?.treeView
+
+  updateFile: ({file, messages}) ->
+    @fileMessages[file] = if messages.length > 0
+      messages
+    else
+      false
+
+    @display()
+
+  getMessagesLevel: (messages) ->
+    messages.reduce (memo, message) ->
+      memo = if message.level == 'error'
+        'error'
+      else if message.level == 'warning' && memo != 'error'
+        'warning'
+    ,''
+
+  # Internal: Render all the linter messages
+  display: ->
+    @getViews()
+    if @showOnTabAndTreeView
+      _.each @fileMessages, (messages, file) =>
+        if messages
+          messageLevel = @addFileLevelIndicator file, @getMessagesLevel messages
+        else
+          @removeFileLevelIndicator(file)
+
+  getSelector: (file) ->
+    '[data-path="' + file + '"]'
+
+  removeFileLevelIndicator: (file) ->
+    @views.forEach (view) =>
+      view.find(@getSelector(file))
+        .removeClass('linter-error')
+        .removeClass('linter-warning')
+
+  addFileLevelIndicator: (file, level) ->
+    @views.forEach (view) =>
+      view.find(@getSelector(file))
+        .addClass('linter-' + level)
+
+  # Public: remove this view and unregister all it's subscriptions
+  remove: ->
+    _.each @messages, (messages, file) =>
+      @removeFileLevelIndicator(file)
+    @subscriptions.dispose()
+
+module.exports = LinterView

--- a/stylesheets/workspace.less
+++ b/stylesheets/workspace.less
@@ -1,0 +1,10 @@
+@import 'octicon-mixins';
+@import 'octicon-utf-codes';
+
+.tab-bar .tab .title.linter-error, .tree-view .name.linter-error {
+    color: @text-color-error !important;
+}
+
+.tab-bar .tab .title.linter-error, .tree-view .name.linter-error {
+    color: @text-color-warning !important;
+}


### PR DESCRIPTION
Adding the ability to track errors at the workspace level.  It currently displays errors on your tab bar and tree view.  

Highlights the file name in both the tab bar and tree view using your standard 'error' or 'warning' text color from your theme.

![tree](https://cloud.githubusercontent.com/assets/276898/5332035/ef08446a-7dfa-11e4-889f-313912674bd5.jpg)

This is requires #278.