### PR TITLE
Add support for message level 'info'.

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -35,10 +35,10 @@ class LinterInitializer
     showErrorInline:
       type: 'boolean'
       default: false
-    hushInfoMessages:
+    showInfoMessages:
       type: 'boolean'
-      default: true
-      description: "Hide “Info” message’s gutter markers and highlighting, showing “Info” only in the status bar."
+      default: false
+      description: "Display linter messages with error level “Info”."
     statusBar:
       type: 'string'
       default: 'Show error of the selected line'

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -35,6 +35,10 @@ class LinterInitializer
     showErrorInline:
       type: 'boolean'
       default: false
+    hushInfoMessages:
+      type: 'boolean'
+      default: true
+      description: "Hide “Info” message’s gutter markers and highlighting, showing “Info” only in the status bar."
     statusBar:
       type: 'string'
       default: 'Show error of the selected line'

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -89,9 +89,9 @@ class LinterView
         @showHighlighting = showHighlighting
         @display()
 
-    @subscriptions.add atom.config.observe 'linter.hushInfoMessages',
-      (hushInfoMessages) =>
-        @hushInfoMessages = hushInfoMessages
+    @subscriptions.add atom.config.observe 'linter.showInfoMessages',
+      (showInfoMessages) =>
+        @showInfoMessages = showInfoMessages
         @display()
 
   # Internal: register handlers for editor buffer events
@@ -177,11 +177,11 @@ class LinterView
 
   # Internal: Pidgeonhole messages onto lines. Each line gets only one message,
   # the message with the highest level presides. Messages of unrecognizable
-  # level (or hushed by config) will be skipped.
+  # level (or silenced by config) will be skipped.
   sortMessagesByLine: (messages) ->
     lines = {}
-    levels = ['info', 'warning', 'error']
-    levels.shift() if @hushInfoMessages
+    levels = ['warning', 'error']
+    levels.unshift('info') if @showInfoMessages
     for message in messages
       lNum = message.line
       line = lines[lNum] || { 'level': -1 }

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -147,13 +147,12 @@ class LinterView
   processMessage: (messages, tempFileInfo, linter) =>
     log "#{linter.linterName} returned", linter, messages
 
+    @messages = @messages.concat(messages)
     tempFileInfo.completedLinters++
     if tempFileInfo.completedLinters == @linters.length
+      @display @messages
       rimraf tempFileInfo.path, (err) ->
         throw err if err?
-
-    @messages = @messages.concat(messages)
-    @display()
 
   # Internal: Destroy all markers (and associated decorations)
   destroyMarkers: ->

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash'
+lodash = require 'lodash'
 fs = require 'fs'
 temp = require 'temp'
 path = require 'path'
@@ -45,8 +45,8 @@ class LinterView
     @linters = []
     grammarName = @editor.getGrammar().scopeName
     for linter in @allLinters
-      if (_.isArray(linter.syntax) and grammarName in linter.syntax or
-          _.isString(linter.syntax) and grammarName is linter.syntax or
+      if (lodash.isArray(linter.syntax) and grammarName in linter.syntax or
+          lodash.isString(linter.syntax) and grammarName is linter.syntax or
           linter.syntax instanceof RegExp and linter.syntax.test(grammarName))
         @linters.push(new linter(@editor))
 
@@ -61,7 +61,7 @@ class LinterView
         throttleInterval = parseInt(lintOnModifiedDelayMS)
         throttleInterval = 1000 if isNaN throttleInterval
         # create throttled lint command
-        @throttledLint = (_.throttle @lint, throttleInterval).bind this
+        @throttledLint = (lodash.throttle @lint, throttleInterval).bind this
 
     @subscriptions.add atom.config.observe 'linter.lintOnChange',
       (lintOnModified) => @lintOnModified = lintOnModified

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -179,8 +179,7 @@ class LinterView
       lNum = message.line
       line = lines[lNum] || { 'level': -1 }
       msg_level = levels.indexOf(message.level)
-      if msg_level <= line.level
-        continue
+      continue unless msg_level > line.level
       line.level = msg_level
       line.msg = message
       lines[lNum] = line
@@ -192,12 +191,12 @@ class LinterView
 
     return unless @editor.isAlive()
 
-    if not (@showGutters or @showHighlighting)
+    unless @showGutters or @showHighlighting
       @updateViews()
       return
 
     @markers ?= []
-    for lNum, line of @sortMessagesByLine(messages)
+    for _, line of @sortMessagesByLine(messages)
       marker = @createMarker(line.msg)
       @markers.push marker
 

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -89,6 +89,11 @@ class LinterView
         @showHighlighting = showHighlighting
         @display()
 
+    @subscriptions.add atom.config.observe 'linter.hushInfoMessages',
+      (hushInfoMessages) =>
+        @hushInfoMessages = hushInfoMessages
+        @display()
+
   # Internal: register handlers for editor buffer events
   handleEditorEvents: =>
     @editor.onDidChangeGrammar =>
@@ -171,10 +176,12 @@ class LinterView
     return marker
 
   # Internal: Pidgeonhole messages onto lines. Each line gets only one message,
-  # the message with the highest level presides.
+  # the message with the highest level presides. Messages of unrecognizable
+  # level (or hushed by config) will be skipped.
   sortMessagesByLine: (messages) ->
     lines = {}
     levels = ['info', 'warning', 'error']
+    levels.shift() if @hushInfoMessages
     for message in messages
       lNum = message.line
       line = lines[lNum] || { 'level': -1 }

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -186,9 +186,9 @@ class LinterView
     for message in messages
       lNum = message.line
       line = lines[lNum] || { 'level': -1 }
-      msg_level = levels.indexOf(message.level)
-      continue unless msg_level > line.level
-      line.level = msg_level
+      msgLevel = levels.indexOf(message.level)
+      continue unless msgLevel > line.level
+      line.level = msgLevel
       line.msg = message
       lines[lNum] = line
     return lines

--- a/lib/statusbar-summary-view.coffee
+++ b/lib/statusbar-summary-view.coffee
@@ -11,25 +11,28 @@ class StatusBarSummaryView
     statusBar = atom.workspaceView.statusBar
     return unless statusBar
 
-    warning = error = 0
+    info = warning = error = 0
 
     for item in messages
       warning += 1 if item.level == 'warning'
       error += 1 if item.level == 'error'
+      info += 1 if item.level == 'info'
 
     # Hide the last version of this view
     @remove()
 
-    @decoration = new StatusBarSummary(warning or 0, error or 0)
+    @decoration = new StatusBarSummary(info or 0, warning or 0, error or 0)
 
     statusBar.prependRight @decoration
 
 class StatusBarSummary extends View
-  @content: (warning, error) ->
+  @content: (info, warning, error) ->
     @div class: 'linter-summary inline-block', =>
+      @div class: 'linter-error inline-block', error, =>
+        @span class: 'icon-right'
       @div class: 'linter-warning inline-block', warning, =>
         @span class: 'icon-right'
-      @div class: 'linter-error inline-block', error, =>
+      @div class: 'linter-info inline-block', info, =>
         @span class: 'icon-right'
 
 module.exports = StatusBarSummaryView

--- a/lib/statusbar-view.coffee
+++ b/lib/statusbar-view.coffee
@@ -75,6 +75,11 @@ class StatusBarView extends View
       @show()
       @highlightLines(currentLine)
 
+  filterInfoMessages: (messages, config)->
+    showInfoMessages = config.get 'linter.showInfoMessages'
+    return messages if showInfoMessages
+    return (msg for msg in messages when msg.level != 'info')
+
   # Render the view
   render: (messages, editor) ->
     statusBarConfig = atom.config.get 'linter.statusBar'
@@ -86,6 +91,8 @@ class StatusBarView extends View
 
     # Hide the last version of this view
     @hide()
+
+    messages = @filterInfoMessages messages, atom.config
 
     # No more errors on the file, return
     return unless messages.length > 0

--- a/spec/linter-view-spec.coffee
+++ b/spec/linter-view-spec.coffee
@@ -56,6 +56,7 @@ describe "LinterView", ->
   messages = [
     {line: 1, level: "info"},
     {line: 1, level: "error"},
+    {line: 1, level: "warning"},
     {line: 9, level: "warning"},
     {line: 9, level: "info"},
     {line: 3, level: "info"},
@@ -68,7 +69,8 @@ describe "LinterView", ->
     sinon.stub(LinterView.prototype, 'handleEditorEvents')
     sinon.stub(LinterView.prototype, 'updateViews')
     lv = new LinterView(stub_editor)
-    lv.showGutters = lv.showHighlighting = lv.hushInfoMessages = true
+    lv.showGutters = lv.showHighlighting = true
+    lv.showInfoMessages = false
 
   afterEach ->
     LinterView.prototype.initLinters.restore()
@@ -80,11 +82,16 @@ describe "LinterView", ->
   describe "message sorting", ->
 
     it "selects the most severe message for each line", ->
-      lv.hushInfoMessages = false
       lines = lv.sortMessagesByLine(messages)
-      expect(lines['1'].level).to.equal(2)
-      expect(lines['3'].level).to.equal(0)
-      expect(lines['9'].level).to.equal(1)
+      expect(lines['1'].msg.level).to.equal('error')
+      expect(lines['9'].msg.level).to.equal('warning')
+
+    it "consults config concerning info messages", ->
+      lv.showInfoMessages = true
+      lines = lv.sortMessagesByLine(messages)
+      expect(lines['1'].msg.level).to.equal('error')
+      expect(lines['3'].msg.level).to.equal('info')
+      expect(lines['9'].msg.level).to.equal('warning')
 
     it "ignores messages of unrecognized levels", ->
       lines = lv.sortMessagesByLine(messages)
@@ -102,7 +109,7 @@ describe "LinterView", ->
       lv.display(messages)
       expect(lv.markers).to.have.length(2)
 
-    it "when info shush is toggled off, info markers are created", ->
-      lv.hushInfoMessages = false
+    it "will show info markers when configured to do so", ->
+      lv.showInfoMessages = true
       lv.display(messages)
       expect(lv.markers).to.have.length(3)

--- a/spec/linter-view-spec.coffee
+++ b/spec/linter-view-spec.coffee
@@ -64,12 +64,15 @@ describe "LinterView", ->
 
   beforeEach ->
     sinon.stub(LinterView.prototype, 'initLinters')
+    sinon.stub(LinterView.prototype, 'handleConfigChanges')
     sinon.stub(LinterView.prototype, 'handleEditorEvents')
     sinon.stub(LinterView.prototype, 'updateViews')
     lv = new LinterView(stub_editor)
+    lv.showGutters = lv.showHighlighting = lv.hushInfoMessages = true
 
   afterEach ->
     LinterView.prototype.initLinters.restore()
+    LinterView.prototype.handleConfigChanges.restore()
     LinterView.prototype.handleEditorEvents.restore()
     LinterView.prototype.updateViews.restore()
 
@@ -77,6 +80,7 @@ describe "LinterView", ->
   describe "message sorting", ->
 
     it "selects the most severe message for each line", ->
+      lv.hushInfoMessages = false
       lines = lv.sortMessagesByLine(messages)
       expect(lines['1'].level).to.equal(2)
       expect(lines['3'].level).to.equal(0)
@@ -94,7 +98,11 @@ describe "LinterView", ->
       lv.display(messages)
       expect(lv.markers).to.not.exist
 
-    it "creates markers for each line with a message", ->
-      lv.showGutters = lv.showHighlighting = true
+    it "creates markers for each line with an error or warning", ->
+      lv.display(messages)
+      expect(lv.markers).to.have.length(2)
+
+    it "when info shush is toggled off, info markers are created", ->
+      lv.hushInfoMessages = false
       lv.display(messages)
       expect(lv.markers).to.have.length(3)

--- a/spec/linter-view-spec.coffee
+++ b/spec/linter-view-spec.coffee
@@ -1,7 +1,12 @@
 sinon = require "sinon"
+chai = require 'chai'
+Editor = require atom.config.resourcePath + "/src/text-editor"
 
 LinterView = require "../lib/linter-view.coffee"
 Linter = require "../lib/linter.coffee"
+
+expect = chai.expect
+
 
 describe "LinterView:lint", ->
   class CatFileLinter extends Linter
@@ -41,3 +46,55 @@ describe "LinterView:lint", ->
     waitsFor ->
       calls is linterClasses.length
     , "lint file finished"
+
+
+describe "LinterView", ->
+
+  lv = null
+  stub_editor = sinon.createStubInstance(Editor)
+  stub_editor.isAlive.returns(true)
+  messages = [
+    {line: 1, level: "info"},
+    {line: 1, level: "error"},
+    {line: 9, level: "warning"},
+    {line: 9, level: "info"},
+    {line: 3, level: "info"},
+    {line: 20, level: "nonsense"}
+  ]
+
+  beforeEach ->
+    sinon.stub(LinterView.prototype, 'initLinters')
+    sinon.stub(LinterView.prototype, 'handleEditorEvents')
+    sinon.stub(LinterView.prototype, 'updateViews')
+    lv = new LinterView(stub_editor)
+
+  afterEach ->
+    LinterView.prototype.initLinters.restore()
+    LinterView.prototype.handleEditorEvents.restore()
+    LinterView.prototype.updateViews.restore()
+
+
+  describe "message sorrting", ->
+
+    it "selects the most severe message for each line", ->
+      lines = lv.sortMessagesByLine(messages)
+      expect(lines['1'].level).to.equal(2)
+      expect(lines['3'].level).to.equal(0)
+      expect(lines['9'].level).to.equal(1)
+
+    it "ignores messages of unrecognized levels", ->
+      lines = lv.sortMessagesByLine(messages)
+      expect(lines).to.not.property('20')
+
+
+  describe "message display", ->
+
+    it "bails if gutters and highlighting is turned off", ->
+      lv.showGutters = lv.showHighlighting = false
+      lv.display(messages)
+      expect(lv.makres).to.not.exist
+
+    it "creates markers for each line with a message", ->
+      lv.showGutters = lv.showHighlighting = true
+      lv.display(messages)
+      expect(lv.markers).to.have.length(3)

--- a/spec/linter-view-spec.coffee
+++ b/spec/linter-view-spec.coffee
@@ -74,7 +74,7 @@ describe "LinterView", ->
     LinterView.prototype.updateViews.restore()
 
 
-  describe "message sorrting", ->
+  describe "message sorting", ->
 
     it "selects the most severe message for each line", ->
       lines = lv.sortMessagesByLine(messages)
@@ -92,7 +92,7 @@ describe "LinterView", ->
     it "bails if gutters and highlighting is turned off", ->
       lv.showGutters = lv.showHighlighting = false
       lv.display(messages)
-      expect(lv.makres).to.not.exist
+      expect(lv.markers).to.not.exist
 
     it "creates markers for each line with a message", ->
       lv.showGutters = lv.showHighlighting = true

--- a/spec/linter-view-spec.coffee
+++ b/spec/linter-view-spec.coffee
@@ -84,7 +84,7 @@ describe "LinterView", ->
 
     it "ignores messages of unrecognized levels", ->
       lines = lv.sortMessagesByLine(messages)
-      expect(lines).to.not.property('20')
+      expect(lines).to.not.have.property('20')
 
 
   describe "message display", ->

--- a/spec/statusbar-view-spec.coffee
+++ b/spec/statusbar-view-spec.coffee
@@ -46,3 +46,14 @@ describe 'StatusBarView', ->
     # html should have correctly added into the status bar
     statusBarView.find('.error-message').text().should.be.eql('bar')
     statusBarView.find('dt > span').text().should.be.eql('foo')
+
+  it "can filter info messages using config", ->
+    messages = [
+      {'level': 'info'},
+      {'level': 'error'},
+      {'level': 'info'}
+    ]
+    fake_config = 
+      get: () -> false
+    filtered = statusBarView.filterInfoMessages(messages, fake_config)
+    filtered.length.should.be.eql(1)

--- a/stylesheets/gutter.atom-text-editor.less
+++ b/stylesheets/gutter.atom-text-editor.less
@@ -2,6 +2,15 @@
 @import 'octicon-utf-codes';
 
 .gutter .line-number {
+  &.linter-info .icon-right {
+    visibility: visible;
+    &:before {
+      color: @text-color-info;
+      content: @primitive-dot;
+      font-size: 1.1em;
+    }
+  }
+
   &.linter-warning .icon-right {
     visibility: visible;
     &:before {

--- a/stylesheets/highlights.atom-text-editor.less
+++ b/stylesheets/highlights.atom-text-editor.less
@@ -1,6 +1,13 @@
 @import 'ui-variables';
 
 .highlight {
+  &.linter-info .region {
+    background-color: darken(@background-color-info, 10%);
+    -webkit-mask-image: url(atom://linter/images/wave.svg);
+    -webkit-mask-repeat: repeat;
+    -webkit-mask-size: .9em 1.3em;
+    -webkit-mask-position: bottom left;
+  }
   &.linter-warning .region {
     background-color: darken(@background-color-warning, 10%);
     -webkit-mask-image: url(atom://linter/images/wave.svg);

--- a/stylesheets/statusbar-summary-view.less
+++ b/stylesheets/statusbar-summary-view.less
@@ -14,6 +14,10 @@
     }
   }
 
+  .linter-info .icon-right:before {
+    color: @text-color-info;
+  }
+
   .linter-warning .icon-right:before {
     color: @text-color-warning;
   }


### PR DESCRIPTION
When styling markers and a line has multiple messages, choose the message
with the level of highest precedence.

Default view:
![screen shot 2015-01-21 at 00 28 17](https://cloud.githubusercontent.com/assets/154988/5831635/73ed2656-a104-11e4-9212-12bdbd36ac0b.png)

ShowInfoMessages turned on: 
![screen shot 2015-01-21 at 00 27 30](https://cloud.githubusercontent.com/assets/154988/5831634/73e0f5f2-a104-11e4-933a-6a1437fbc34a.png)
