### PR TITLE
Fix crash on load

### DIFF
--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -51,7 +51,7 @@ class Linter
 
   # Public: Construct a linter passing it's base editor
   constructor: (@editor) ->
-    @cwd = path.dirname(@editor.getURI())
+    @cwd = path.dirname(@editor.getPath())
 
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter.executionTimeout', (x) =>


### PR DESCRIPTION
Fixes #389 

The function getUri() is called on @editor, however, this function does not seem to exist. Changed to getPath().