### PR TITLE
Push top-level require() calls down into the functions that use them.

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,10 +1,4 @@
-_ = require 'lodash'
-{CompositeDisposable} = require 'event-kit'
-
-LinterView = require './linter-view'
-StatusBarView = require './statusbar-view'
-StatusBarSummaryView = require './statusbar-summary-view'
-InlineView = require './inline-view'
+{CompositeDisposable} = require 'atom'
 
 
 # Public: linter package initialization, sets up the linter for usages by atom
@@ -76,11 +70,16 @@ class LinterInitializer
         linterClasses.push(require "#{atomPackage.path}/lib/#{implemention}")
 
     @enabled = true
+    StatusBarView = require './statusbar-view'
     @statusBarView = new StatusBarView()
+    StatusBarSummaryView = require './statusbar-summary-view'
     @statusBarSummaryView = new StatusBarSummaryView()
+    InlineView = require './inline-view'
     @inlineView = new InlineView()
 
     # Subscribing to every current and future editor
+    LinterView = require './linter-view'
+    _ = require 'lodash'
     @subscriptions.add atom.workspace.observeTextEditors (editor) =>
       return if editor.linterView?
 


### PR DESCRIPTION
This follows the first suggestion on
https://discuss.atom.io/t/how-to-speed-up-your-packages/10903.

Previous to this diff, `linter` would take over 200ms to load on my
machine, according to Timecop. Now when I run:

    atom.packages.getLoadedPackage('linter').loadTime

I consistently see `linter` loading in under 10ms (it's usually <5ms).

Activation time has not seemed to increase dramatically as a result:

    atom.packages.getLoadedPackage('linter').activateTime

Seems to hover around 80ms.

I can probably do even better in follow-up diffs.