### PR TITLE
Remove event-kit dependency.

### DIFF
--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -3,7 +3,7 @@ fs = require 'fs'
 temp = require 'temp'
 path = require 'path'
 rimraf = require 'rimraf'
-{CompositeDisposable, Emitter} = require 'event-kit'
+{CompositeDisposable, Emitter} = require 'atom'
 
 {log, warn} = require './utils'
 

--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -1,9 +1,8 @@
 fs = require 'fs'
 path = require 'path'
-{Range, Point, BufferedProcess} = require 'atom'
+{CompositeDisposable, Range, Point, BufferedProcess} = require 'atom'
 _ = require 'lodash'
 {XRegExp} = require 'xregexp'
-{CompositeDisposable} = require 'event-kit'
 
 {log, warn} = require './utils'
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "chai": "^1.9.1",
     "emissary": "^1.0.0",
-    "event-kit": "^0.8.1",
     "jshint": "^2.4.4",
     "lodash": "^2.4.1",
     "rimraf": "^2.2.8",


### PR DESCRIPTION
Both `CompositeDisposable` and `Emitter` are available on `require('atom')`.

I even made sure that `require('event-kit').Emitter === require('atom').Emitter`
was `true`.