### PR TITLE
Make Linter load faster since all clients need to load this class.

### DIFF
--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -1,8 +1,8 @@
 fs = require 'fs'
 path = require 'path'
 {CompositeDisposable, Range, Point, BufferedProcess} = require 'atom'
-_ = require 'lodash'
-{XRegExp} = require 'xregexp'
+_ = null
+XRegExp = null
 
 {log, warn} = require './utils'
 
@@ -56,13 +56,19 @@ class Linter
     @subscriptions.add atom.config.observe 'linter.executionTimeout', (x) =>
       @executionTimeout = x
 
+    @_statCache = new Map()
+
   destroy: ->
     @subscriptions.dispose()
 
   # Private: Exists mostly so we can use statSync without slowing down linting.
   # TODO: Do this at constructor time?
-  _cachedStatSync: _.memoize (path) ->
-    fs.statSync path
+  _cachedStatSync: (path) ->
+    stat = @_statCache.get path
+    unless stat
+      stat = fs.statSync path
+      @_statCache.set(path, stat)
+    stat
 
   # Private: get command and args for atom.BufferedProcess for execution
   getCmdAndArgs: (filePath) ->
@@ -166,6 +172,7 @@ class Linter
   # for instance if the linter returns json or xml data
   processMessage: (message, callback) ->
     messages = []
+    XRegExp ?= require('xregexp').XRegExp
     regex = XRegExp @regex, @regexFlags
     XRegExp.forEach message, regex, (match, i) =>
       msg = @createMessage match
@@ -224,6 +231,7 @@ class Linter
     return text?.length or 0
 
   getEditorScopesForPosition: (position) ->
+    _ ?= require 'lodash'
     try
       # return a copy in case it gets mutated (hint: it does)
       _.clone @editor.displayBuffer.tokenizedBuffer.scopesForPosition(position)


### PR DESCRIPTION
Defers the loading of lodash and XRegExp until they are used.
Replaced _.memoize() with custom logic to pave the way to removing
the lodash dependency altogether in Linter.

The only other top-level `require()` calls that could be eliminated
are for `log` and `warn`.

One thing that I found a little odd is that, assuming `@executablePath`
never changes over the lifetime of the `Linter` once it is set,
`@_statCache` will only ever have one entry in it.