### PR TITLE
support clearing warning on change

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -12,6 +12,9 @@ class LinterInitializer
     lintOnChange:
       type: 'boolean'
       default: true
+    clearOnChange:
+      type: 'boolean'
+      default: false
     lintOnEditorFocus:
       type: 'boolean'
       default: true

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -111,6 +111,8 @@ class LinterView
       if @lintOnModified
         @throttledLint()
       else if @clearOnChange
+        @messages = []
+        @updateViews()
         @destroyMarkers()
 
     @subscriptions.add @editor.onDidDestroy =>

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -94,6 +94,9 @@ class LinterView
         @showInfoMessages = showInfoMessages
         @display()
 
+    @subscriptions.add atom.config.observe 'linter.clearOnChange',
+      (clearOnChange) => @clearOnChange = clearOnChange
+
   # Internal: register handlers for editor buffer events
   handleEditorEvents: =>
     @editor.onDidChangeGrammar =>
@@ -105,7 +108,10 @@ class LinterView
     @subscriptions.add(@editor.onDidSave maybeLintOnSave)
 
     @subscriptions.add @editor.onDidStopChanging =>
-      @throttledLint() if @lintOnModified
+      if @lintOnModified
+        @throttledLint()
+      else if @clearOnChange
+        @destroyMarkers()
 
     @subscriptions.add @editor.onDidDestroy =>
       @remove()


### PR DESCRIPTION
Perhaps this was undesired behavior for most, but I loved the way that sublime-linter would clear out the errors as soon as you started typing.

This change brings that feature to AtomLinter behind an off-by-default setting "Clear On Change".

![image](https://cloud.githubusercontent.com/assets/1329312/6278935/771d8346-b858-11e4-92b7-e7714a1ebf9f.png)
