### PR TITLE
Handle missing linter executable

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -45,6 +45,16 @@ class LinterInitializer
       type: 'integer'
       default: 5000
       description: 'Linter executables are killed after this timeout. Set to 0 to disable.'
+    ignoredLinterErrors:
+      type: 'array'
+      default: []
+      items:
+        type: 'string'
+    subtleLinterErrors:
+      type: 'array'
+      default: []
+      items:
+        type: 'string'
 
   # Internal: Prevent old deprecated config to be visible in the package settings
   setDefaultOldConfig: ->

--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -161,19 +161,20 @@ class Linter
       if err.error.code is 'ENOENT'
         ignored = atom.config.get('linter.ignoredLinterErrors')
         subtle = atom.config.get('linter.subtleLinterErrors')
+        warningMessageTitle = "The linter binary '#{@linterName}' cannot be found."
         if @linterName in subtle
           # Show a small notification at the bottom of the screen
-          new MessagePanelView(
-            title: "#{@linterName} linter not installed"
-          ).attach()
+          message = new MessagePanelView(title: warningMessageTitle)
+          message.attach()
+          message.toggle() # Fold the panel
         else if @linterName not in ignored
           # Prompt user, ask if they want to fully or partially ignore warnings
           atom.confirm
-            message: "Oops, you don't have the linter #{@linterName} installed"
-            detailedMessage: 'Please follow the installation guide for your
-            linter. Would you like further notifications to be fully or
-            partially suppressed? You can change this later in the linter
-            package settings.'
+            message: warningMessageTitle
+            detailedMessage: 'Is it on your path? Please follow the installation
+            guide for your linter. Would you like further notifications to be
+            fully or partially suppressed? You can change this later in the
+            linter package settings.'
             buttons:
               Fully: =>
                 ignored.push @linterName
@@ -182,7 +183,7 @@ class Linter
                 subtle.push @linterName
                 atom.config.set('linter.subtleLinterErrors', subtle)
         else
-          console.log "linter #{@linterName} not installed"
+          console.log warningMessageTitle
         err.handle()
 
     # Kill the linter process if it takes too long

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
+    "atom-message-panel": "^1.2.2",
     "chai": "^1.9.1",
     "emissary": "^1.0.0",
     "jshint": "^2.4.4",


### PR DESCRIPTION
The user is prompted the first time a missing executable is detected
and given the option of fully or partially ignoring further warnings.
If warnings are partially ignored, a small notification will be
displayed at the bottom of the editor each time a missing executable
is detected.