### PR TITLE
Added Reek linter to Ruby section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The idea is to stop the linter plugins war, by providing a top level API for lin
 - [linter-ruby](https://atom.io/packages/linter-ruby), for Ruby, using `ruby -wc`
 - [linter-erb](https://atom.io/packages/linter-erb), for .erb files, using `erb -x`
 - [linter-haml](https://atom.io/packages/linter-haml), for .haml files, using `haml-lint`
+- [linter-reek](https://atom.io/packages/linter-reek), for Ruby, using `reek`
 
 #### for PHP
 - [linter-php](https://atom.io/packages/linter-php), for PHP using `php -l`


### PR DESCRIPTION
In reference to Issue #413, as I published that linter today.