### PR TITLE
:bug: Fix wavy underline with non-standard line height #427

### DIFF
--- a/styles/highlights.atom-text-editor.less
+++ b/styles/highlights.atom-text-editor.less
@@ -4,21 +4,21 @@
   &.linter-info .region {
     background-color: @background-color-info;
     -webkit-mask-image: url(atom://linter/images/wave.svg);
-    -webkit-mask-repeat: repeat;
+    -webkit-mask-repeat: repeat-x;
     -webkit-mask-size: .9em 1.3em;
     -webkit-mask-position: bottom left;
   }
   &.linter-warning .region {
     background-color: darken(@background-color-warning, 15%);
     -webkit-mask-image: url(atom://linter/images/wave.svg);
-    -webkit-mask-repeat: repeat;
+    -webkit-mask-repeat: repeat-x;
     -webkit-mask-size: .9em 1.3em;
     -webkit-mask-position: bottom left;
   }
   &.linter-error .region {
     background-color: @background-color-error;
     -webkit-mask-image: url(atom://linter/images/wave.svg);
-    -webkit-mask-repeat: repeat;
+    -webkit-mask-repeat: repeat-x;
     -webkit-mask-size: .9em 1.3em;
     -webkit-mask-position: bottom left;
   }


### PR DESCRIPTION
When line height is increased from the standard line height, wavy underlines were repeated vertically causing duplicate lines.