### PR TITLE
Try using writeSync and closeSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Upcoming
-* Fix a bug where messages from legacy provider
+
+* Treat legacy messages as text instead of html
+* Fix a bug causing linter messages to briefly disappear and reappear
 
 # 1.0.2
 

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -54,14 +54,13 @@ module.exports = (ClassicLinter) ->
         temp.open(tmpOptions, (err, info) ->
           return reject(err) if err
 
-          fs.write(info.fd, textEditor.getText())
-          fs.close(info.fd, (err) ->
-            return reject(err) if err
-            linter.lintFile(info.path, (results) ->
-              fs.unlink(info.path)
+          fs.writeSync(info.fd, textEditor.getText())
+          fs.closeSync(info.fd)
 
-              resolve(transform(filePath, textEditor, results))
-            )
+          linter.lintFile(info.path, (results) ->
+            fs.unlink(info.path)
+
+            resolve(transform(filePath, textEditor, results))
           )
         )
       )

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -54,14 +54,17 @@ module.exports = (ClassicLinter) ->
         temp.open(tmpOptions, (err, info) ->
           return reject(err) if err
 
-          fs.writeSync(info.fd, textEditor.getText())
-          fs.closeSync(info.fd)
+          try
+            fs.writeSync(info.fd, textEditor.getText())
+            fs.closeSync(info.fd)
 
-          linter.lintFile(info.path, (results) ->
-            fs.unlink(info.path)
+            linter.lintFile(info.path, (results) ->
+              fs.unlink(info.path)
 
-            resolve(transform(filePath, textEditor, results))
-          )
+              resolve(transform(filePath, textEditor, results))
+            )
+          catch error
+            reject(error)
         )
       )
   }


### PR DESCRIPTION
Fixes #596 

@iam4x Will you try this branch and see if it fixes the problem? I can't reproduce it.

My best theory is that because `fs.write` and `fs.close` are both asynchronous it sometimes closes the file before it finishes writing. I don't know if running Linux or maybe having an SSD causes me to not run into this problem.