### PR TITLE
Add command set-bubble-transparent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Fix message render for non TextEditor panes (Fixes #610)
 * Make the bubble follow cursor
 * Show a nicer error if linter binary doesn't exist (Fixes #612)
-* Add set-bubble-transparent to set the bubble transparent until the key is released (Fixes #608)
+* Add set-bubble-transparent command to set the bubble transparent until the key is released (Fixes #608)
 
 # 1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix message render for non TextEditor panes (Fixes #610)
 * Make the bubble follow cursor
 * Show a nicer error if linter binary doesn't exist (Fixes #612)
+* Add set-bubble-transparent to set the bubble transparent until the key is released (Fixes #608)
 
 # 1.0.4
 

--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -6,7 +6,7 @@ class Commands
     @_subscriptions.add atom.commands.add 'atom-workspace',
       'linter:next-error': @nextError.bind(@)
       'linter:toggle': @toggleLinter.bind(@)
-      'linter:set-bubble-transparent': @setBubleTransparent.bind(@)
+      'linter:set-bubble-transparent': @setBubleTransparent
 
     # Default values
     @_messages = null
@@ -16,7 +16,7 @@ class Commands
     return unless activeEditorLinter
     activeEditorLinter.toggleStatus()
 
-  setBubleTransparent: ->
+  setBubleTransparent: =>
     @linter.views.setBubbleTransparent()
 
   nextError: ->

--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -6,6 +6,7 @@ class Commands
     @_subscriptions.add atom.commands.add 'atom-workspace',
       'linter:next-error': @nextError.bind(@)
       'linter:toggle': @toggleLinter.bind(@)
+      'linter:set-bubble-transparent': @setBubleTransparent.bind(@)
 
     # Default values
     @_messages = null
@@ -14,6 +15,9 @@ class Commands
     activeEditorLinter = @linter.getActiveEditorLinter()
     return unless activeEditorLinter
     activeEditorLinter.toggleStatus()
+
+  setBubleTransparent: ->
+    @linter.getActiveEditorLinter()?.setBubbleTransparent()
 
   nextError: ->
     if not @_messages or (next = @_messages.next()).done

--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -17,7 +17,7 @@ class Commands
     activeEditorLinter.toggleStatus()
 
   setBubleTransparent: ->
-    @linter.getActiveEditorLinter()?.setBubbleTransparent()
+    @linter.views.setBubbleTransparent()
 
   nextError: ->
     if not @_messages or (next = @_messages.next()).done

--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -6,7 +6,7 @@ class Commands
     @_subscriptions.add atom.commands.add 'atom-workspace',
       'linter:next-error': @nextError.bind(@)
       'linter:toggle': @toggleLinter.bind(@)
-      'linter:set-bubble-transparent': @setBubleTransparent
+      'linter:set-bubble-transparent': => @setBubleTransparent()
 
     # Default values
     @_messages = null
@@ -16,7 +16,7 @@ class Commands
     return unless activeEditorLinter
     activeEditorLinter.toggleStatus()
 
-  setBubleTransparent: =>
+  setBubleTransparent: ->
     @linter.views.setBubbleTransparent()
 
   nextError: ->

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -25,9 +25,6 @@ class EditorLinter
   toggleStatus: ->
     @setStatus !@_status
 
-  setBubbleTransparent: ->
-    @linter.views.setBubbleTransparent()
-
   getStatus: ->
     @_status
 

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -25,6 +25,9 @@ class EditorLinter
   toggleStatus: ->
     @setStatus !@_status
 
+  setBubbleTransparent: ->
+    @linter.views.setBubbleTransparent()
+
   getStatus: ->
     @_status
 

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -48,6 +48,18 @@ class LinterViews
   setShowBubble: (showBubble) ->
     @_showBubble = showBubble
 
+  setBubbleOpaque: ->
+    bubble = document.getElementById('linter-inline')
+    if bubble
+      bubble.classList.remove 'transparent'
+    document.removeEventListener 'keyup', @setBubbleOpaque
+
+  setBubbleTransparent: ->
+    bubble = document.getElementById('linter-inline')
+    if bubble
+      bubble.classList.add 'transparent'
+      document.addEventListener 'keyup', @setBubbleOpaque
+
   # This message is called in editor-linter.coffee
   render: ->
     counts = {project: 0, file: 0}

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -53,12 +53,14 @@ class LinterViews
     if bubble
       bubble.classList.remove 'transparent'
     document.removeEventListener 'keyup', @setBubbleOpaque
+    window.removeEventListener 'blur', @setBubbleOpaque
 
   setBubbleTransparent: ->
     bubble = document.getElementById('linter-inline')
     if bubble
       bubble.classList.add 'transparent'
       document.addEventListener 'keyup', @setBubbleOpaque
+      window.addEventListener 'blur', @setBubbleOpaque
 
   # This message is called in editor-linter.coffee
   render: ->

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -32,6 +32,11 @@ linter-message {
   background: @linter-inline-bg;
   box-shadow: 0 1px 3px hsla(0, 0, 0%, 0.4);
 
+  transition: opacity 300ms;
+  &.transparent {
+    opacity: 0.2;
+  }
+
   // pointer arrow
   &::before {
     content: "";


### PR DESCRIPTION
I add a command to set the bubble transparent. This can be be mapped to a key. On the next keyup event the bubble is set opaque again.

```
'atom-text-editor:not(.mini)':
  'ctrl': 'linter:set-bubble-transparent'
```

This was discussed here: #608