### PR TITLE
change the 'Errors' text to 'Issues'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.7
+# Upcoming
 
 * Rename the status line summary (from `Errors` to `Issues`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.7
+
+* Rename the status line summary (from `Errors` to `Issues`)
+
 # 1.0.6
 
 * Hide Status Bar buttons when Active Pane is not an editor

--- a/lib/views/bottom-status.js
+++ b/lib/views/bottom-status.js
@@ -21,7 +21,7 @@ class BottomStatus extends HTMLElement{
       this.classList.add('status-error')
       this.iconSpan.classList.add('icon-x')
 
-      this.iconSpan.textContent = Value === 1 ? '1 Error' : `${Value} Errors`
+      this.iconSpan.textContent = Value === 1 ? '1 Issue' : `${Value} Issues`
     } else {
       this.classList.remove('status-error')
       this.iconSpan.classList.remove('icon-x')
@@ -29,7 +29,7 @@ class BottomStatus extends HTMLElement{
       this.classList.add('status-success')
       this.iconSpan.classList.add('icon-check')
 
-      this.iconSpan.textContent = 'No Errors'
+      this.iconSpan.textContent = 'No Issues'
     }
   }
 


### PR DESCRIPTION
Rename the `Errors` text on the status line to `Issues`. When there are only info or warning level items, it's a bit alarming to the user to call them errors.

I see there's another PR in this space, but I wanted to throw this out there as a pretty small delta to the current UI.

![screen shot 2015-06-26 at 11 01 55 am](https://cloud.githubusercontent.com/assets/1269969/8384140/cba64854-1bf3-11e5-9a4d-b8b4fe6b7360.png)
