### PR TITLE
change 'current file' text to just 'file'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Upcoming
 
 * Rename the status line summary (from `Errors` to `Issues`)
+* Rename the `Current File` tab to just `File`
 
 # 1.0.6
 

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -16,7 +16,7 @@ class LinterViews
     @_bubble = null
     @_bottomStatus = new BottomStatus()
 
-    @_bottomTabFile.initialize("Current File", =>
+    @_bottomTabFile.initialize("File", =>
       @_changeTab('file')
     )
     @_bottomTabProject.initialize("Project", =>


### PR DESCRIPTION
Change the `Current File` tab title to just `File`. This matches the `Project` tab a bit better, and is more terse - status bar space is at a premium :)

