### PR TITLE
Add tab to show only errors in current line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add some default keybindings (Fixes #597)
 * UI is rendered when Messages are changed pragmatically (Fixes #639)
+* Add optional tab `Line` to show only errors of the current line.
 
 # 1.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * Add some default keybindings (Fixes #597)
 * UI is rendered when Messages are changed pragmatically (Fixes #639)
-* Add optional tab `Line` to show only errors of the current line.
+* Add tab `Line` to show only errors of the current line.
+* Add config options to hide individual tabs (`Line`, `File`, `Project`).
 
 # 1.0.8
 

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -8,7 +8,8 @@ class EditorLinter
     @_inProgress = false
     @_inProgressFly = false
 
-    @linter.views.updateCurrentLine @editor.getCursorBufferPosition()?.row
+    if @editor is atom.workspace.getActiveTextEditor()
+      @linter.views.updateCurrentLine @editor.getCursorBufferPosition()?.row
 
     @_emitter = new Emitter
     @_subscriptions = new CompositeDisposable

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -8,6 +8,8 @@ class EditorLinter
     @_inProgress = false
     @_inProgressFly = false
 
+    @linter.views.updateCurrentLine @editor.getCursorBufferPosition()?.row
+
     @_emitter = new Emitter
     @_subscriptions = new CompositeDisposable
 
@@ -16,6 +18,7 @@ class EditorLinter
     )
     @_subscriptions.add(
       @editor.onDidChangeCursorPosition ({newBufferPosition}) =>
+        @linter.views.updateCurrentLine(newBufferPosition.row)
         @linter.views.updateBubble(newBufferPosition)
     )
     @_subscriptions.add(

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -135,6 +135,7 @@ class LinterViews
     if @_currentLine isnt line
       @_currentLine = line
       @_updateLineMessages()
+      @_renderPanel()
 
 
   _updateLineMessages: ->
@@ -143,12 +144,10 @@ class LinterViews
       return unless editorLinter.editor is activeEditor
 
       @_lineMessages = []
-      editorLinter.getMessages().forEach (Gen) =>
-        Gen.forEach (message) =>
-          @_lineMessages.push message if message.range?.intersectsRow @_currentLine
-
+      @_messages.forEach (message) =>
+        if message.currentFile and message.range?.intersectsRow @_currentLine
+          @_lineMessages.push message
       @_tabs.get('line').count = @_lineMessages.length
-      @_renderPanel()
 
   # This method is called when we get the status-bar service
   attachBottom: (statusBar) ->

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -160,7 +160,8 @@ class LinterViews
     @statusTiles.push statusBar.addLeftTile
       item: @tabs.get('project'),
       priority: -1000
-    @statusTiles.push statusBar.addRightTile
+    statusIconPosition = atom.config.get('linter.statusIconPosition')
+    @statusTiles.push statusBar["add#{statusIconPosition}Tile"]
       item: @bottomStatus,
       priority: 999
 

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -33,7 +33,7 @@ class LinterViews
     # Set default tab
     visibleTabs = @getVisibleTabKeys()
 
-    @scope = atom.config.get('linter.defaultErrorTab', 'file')
+    @scope = atom.config.get('linter.defaultErrorTab', 'File')?.toLowerCase()
     if visibleTabs.indexOf(@scope) is -1
       @scope = visibleTabs[0]
 

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -12,6 +12,7 @@ class LinterViews
     @_markers = []
     @_statusTiles = []
 
+
     @_bottomTabLine = new BottomTab()
     @_bottomTabFile = new BottomTab()
     @_bottomTabProject = new BottomTab()
@@ -23,7 +24,6 @@ class LinterViews
       @_changeTab('line')
     )
     @_bottomTabFile.initialize("File", =>
-
       @_changeTab('file')
     )
     @_bottomTabProject.initialize("Project", =>
@@ -34,9 +34,15 @@ class LinterViews
       atom.commands.dispatch atom.views.getView(atom.workspace), 'linter:next-error'
     @_panelWorkspace = atom.workspace.addBottomPanel item: @_panel, visible: false
 
-    # Set default tab to File
-    @_scope = 'file'
-    @_bottomTabFile.active = true
+    # Set default tab
+    @_scope = atom.config.get('linter.defaultErrorTab')
+    if @_scope is 'line' and not atom.config.get('linter.showErrorLineTab')
+      @_scope = 'file'
+
+    @_bottomTabLine.active = @_scope is 'line'
+    @_bottomTabFile.active = @_scope is 'file'
+    @_bottomTabProject.active = @_scope is 'project'
+
     @_panel.id = 'linter-panel'
 
   getMessages: ->
@@ -79,7 +85,6 @@ class LinterViews
 
   # This message is called in editor-linter.coffee
   render: ->
-    console.log 'render'
     counts = {project: 0, file: 0}
     @_messages.clear()
     @linter.eachEditorLinter (editorLinter) =>
@@ -93,6 +98,7 @@ class LinterViews
     @_bottomTabProject.count = counts.project
     @_bottomStatus.count = counts.project
     hasActiveEditor = typeof atom.workspace.getActiveTextEditor() isnt 'undefined'
+    @_bottomTabLine.visibility = hasActiveEditor and atom.config.get('linter.showErrorLineTab')
     @_bottomTabFile.visibility = hasActiveEditor
     @_bottomTabProject.visibility = hasActiveEditor
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -11,10 +11,18 @@ module.exports =
       title: 'Show Error Panel at the bottom'
       type: 'boolean'
       default: true
-    showErrorLineTab:
+    showErrorTabLine:
       title: 'Show line tab in error panel'
       type: 'boolean'
       default: false
+    showErrorTabFile:
+      title: 'Show file tab in error panel'
+      type: 'boolean'
+      default: true
+    showErrorTabProject:
+      title: 'Show project tab in error panel'
+      type: 'boolean'
+      default: true
     defaultErrorTab:
       type: 'string'
       default: 'file'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -25,8 +25,8 @@ module.exports =
       default: true
     defaultErrorTab:
       type: 'string'
-      default: 'file'
-      enum: ['line', 'file', 'project']
+      default: 'File'
+      enum: ['Line', 'File', 'Project']
     showErrorInline:
       title: 'Show Inline Tooltips'
       descriptions: 'Show inline tooltips for errors'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -11,6 +11,14 @@ module.exports =
       title: 'Show Error Panel at the bottom'
       type: 'boolean'
       default: true
+    showErrorLineTab:
+      title: 'Show line tab in error panel'
+      type: 'boolean'
+      default: false
+    defaultErrorTab:
+      type: 'string'
+      default: 'file'
+      enum: ['line', 'file', 'project']
     showErrorInline:
       title: 'Show Inline Tooltips'
       descriptions: 'Show inline tooltips for errors'

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -65,11 +65,11 @@ linter-bottom-tab {
   border: 1px solid @button-border-color;
   background: fade(@button-background-color, 33%);
   cursor: pointer;
-  &:first-of-type {
+  &.first-tab {
     border-top-left-radius: @component-border-radius;
     border-bottom-left-radius: @component-border-radius;
   }
-  &:last-of-type {
+  &.last-tab {
     margin-right: .6em;
     border-top-right-radius: @component-border-radius;
     border-bottom-right-radius: @component-border-radius;


### PR DESCRIPTION
I added a third tab to the bottom which lets you filter the messages in the panel to show only error of the current line.

This is still work in progress. But I would like to know what you guys think of this idea.

![screen-recording](https://cloud.githubusercontent.com/assets/423234/8388338/297517ea-1c61-11e5-9bc3-6c845f8a86da.gif)

Fixes #587.