### PR TITLE
Remove underscores from the CodeBase

### DIFF
--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -2,8 +2,8 @@
 
 class Commands
   constructor: (@linter) ->
-    @_subscriptions = new CompositeDisposable
-    @_subscriptions.add atom.commands.add 'atom-workspace',
+    @subscriptions = new CompositeDisposable
+    @subscriptions.add atom.commands.add 'atom-workspace',
       'linter:next-error': => @nextError()
       'linter:toggle': => @toggleLinter()
       'linter:set-bubble-transparent': => @setBubbleTransparent()
@@ -38,6 +38,6 @@ class Commands
 
   destroy: ->
     @_messages = null
-    @_subscriptions.dispose()
+    @subscriptions.dispose()
 
 module.exports = Commands

--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -10,7 +10,7 @@ class Commands
       'linter:lint': => @lint()
 
     # Default values
-    @_messages = null
+    @messages = null
 
   toggleLinter: ->
     @linter.getActiveEditorLinter()?.toggleStatus()
@@ -27,8 +27,8 @@ class Commands
       atom.notifications.addError error.message, {detail: error.stack, dismissable: true}
 
   nextError: ->
-    if not @_messages or (next = @_messages.next()).done
-      next = (@_messages = @linter.views.getMessages().values()).next()
+    if not @messages or (next = @messages.next()).done
+      next = (@messages = @linter.views.getMessages().values()).next()
     return if next.done # There's no errors
     message = next.value
     return unless message.filePath
@@ -37,7 +37,7 @@ class Commands
       atom.workspace.getActiveTextEditor().setCursorBufferPosition(message.range.start)
 
   destroy: ->
-    @_messages = null
+    @messages = null
     @subscriptions.dispose()
 
 module.exports = Commands

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -60,13 +60,13 @@ class EditorLinter
     return unless @status
     return unless @editor is atom.workspace.getActiveTextEditor()
     return unless @editor.getPath()
-    return if @_lock(wasTriggeredOnChange)
+    return if @lock(wasTriggeredOnChange)
 
     scopes = @editor.scopeDescriptorForBufferPosition(@editor.getCursorBufferPosition()).scopes
     scopes.push '*' # To allow global linters
 
-    Promise.all(@_lint(wasTriggeredOnChange, scopes)).then =>
-      @_lock(wasTriggeredOnChange, false)
+    Promise.all(@lint(wasTriggeredOnChange, scopes)).then =>
+      @lock(wasTriggeredOnChange, false)
 
   # This method returns an array of promises to be used in lint
   _lint: (wasTriggeredOnChange, scopes) ->
@@ -91,7 +91,7 @@ class EditorLinter
     Promises
 
   # This method sets or gets the lock status of given type
-  _lock: (wasTriggeredOnChange, value) ->
+  lock: (wasTriggeredOnChange, value) ->
     key =
       if wasTriggeredOnChange
         'inProgressFly'

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -65,11 +65,11 @@ class EditorLinter
     scopes = @editor.scopeDescriptorForBufferPosition(@editor.getCursorBufferPosition()).scopes
     scopes.push '*' # To allow global linters
 
-    Promise.all(@lint(wasTriggeredOnChange, scopes)).then =>
+    Promise.all(@triggerLinters(wasTriggeredOnChange, scopes)).then =>
       @lock(wasTriggeredOnChange, false)
 
   # This method returns an array of promises to be used in lint
-  _lint: (wasTriggeredOnChange, scopes) ->
+  triggerLinters: (wasTriggeredOnChange, scopes) ->
     Promises = []
     @linter.getLinters().forEach (linter) =>
       if @linter.lintOnFly

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -13,38 +13,38 @@ class Linter
     @commands = new Commands this
 
     # Private Stuff
-    @_subscriptions = new CompositeDisposable
-    @_emitter = new Emitter
-    @_editorLinters = new Map
-    @_messagesProject = new Map # Values set in editor-linter and consumed in views.render
-    @_linters = new Set # Values are pushed here from Main::consumeLinter
+    @subscriptions = new CompositeDisposable
+    @emitter = new Emitter
+    @editorLinters = new Map
+    @messagesProject = new Map # Values set in editor-linter and consumed in views.render
+    @linters = new Set # Values are pushed here from Main::consumeLinter
 
-    @_subscriptions.add atom.config.observe 'linter.showErrorInline', (showBubble) =>
+    @subscriptions.add atom.config.observe 'linter.showErrorInline', (showBubble) =>
       @views.setShowBubble(showBubble)
-    @_subscriptions.add atom.config.observe 'linter.showErrorPanel', (showPanel) =>
+    @subscriptions.add atom.config.observe 'linter.showErrorPanel', (showPanel) =>
       @views.setShowPanel(showPanel)
-    @_subscriptions.add atom.config.observe 'linter.underlineIssues', (underlineIssues) =>
+    @subscriptions.add atom.config.observe 'linter.underlineIssues', (underlineIssues) =>
       @views.setUnderlineIssues(underlineIssues)
-    @_subscriptions.add atom.config.observe 'linter.lintOnFly', (value) =>
+    @subscriptions.add atom.config.observe 'linter.lintOnFly', (value) =>
       @lintOnFly = value
-    @_subscriptions.add atom.project.onDidChangePaths =>
+    @subscriptions.add atom.project.onDidChangePaths =>
       @commands.lint()
-    @_subscriptions.add atom.workspace.onDidChangeActivePaneItem =>
+    @subscriptions.add atom.workspace.onDidChangeActivePaneItem =>
       @commands.lint()
 
-    @_subscriptions.add atom.workspace.observeTextEditors (editor) =>
+    @subscriptions.add atom.workspace.observeTextEditors (editor) =>
       currentEditorLinter = new EditorLinter @, editor
-      @_editorLinters.set editor, currentEditorLinter
-      @_emitter.emit 'observe-editor-linters', currentEditorLinter
+      @editorLinters.set editor, currentEditorLinter
+      @emitter.emit 'observe-editor-linters', currentEditorLinter
       currentEditorLinter.lint false
       editor.onDidDestroy =>
         currentEditorLinter.destroy()
-        @_editorLinters.delete editor
+        @editorLinters.delete editor
 
   addLinter: (linter) ->
     try
       if(Helpers.validateLinter(linter))
-        @_linters.add(linter)
+        @linters.add(linter)
     catch err
       atom.notifications.addError("Invalid Linter: #{err.message}", {
         detail: err.stack,
@@ -53,7 +53,7 @@ class Linter
 
   deleteLinter: (linter) ->
     return unless @hasLinter(linter)
-    @_linters.delete(linter)
+    @linters.delete(linter)
     if linter.scope is 'project'
       @deleteProjectMessages(linter)
     else
@@ -63,42 +63,42 @@ class Linter
     @views.render()
 
   hasLinter: (linter) ->
-    @_linters.has(linter)
+    @linters.has(linter)
 
   getLinters: ->
-    @_linters
+    @linters
 
   onDidChangeProjectMessages: (callback)->
-    @_emitter.on 'did-change-project-messages', callback
+    @emitter.on 'did-change-project-messages', callback
 
   getProjectMessages: ->
-    @_messagesProject
+    @messagesProject
 
   setProjectMessages: (linter, messages) ->
-    @_messagesProject.set(linter, Helpers.validateResults(messages))
-    @_emitter.emit 'did-change-project-messages', @_messagesProject
+    @messagesProject.set(linter, Helpers.validateResults(messages))
+    @emitter.emit 'did-change-project-messages', @messagesProject
     @views.render()
 
   deleteProjectMessages: (linter) ->
-    @_messagesProject.delete(linter)
-    @_emitter.emit 'did-change-project-messages', @_messagesProject
+    @messagesProject.delete(linter)
+    @emitter.emit 'did-change-project-messages', @messagesProject
     @views.render()
 
   getActiveEditorLinter: ->
     return @getEditorLinter atom.workspace.getActiveTextEditor()
 
   getEditorLinter: (editor) ->
-    return @_editorLinters.get editor
+    return @editorLinters.get editor
 
   eachEditorLinter: (callback) ->
-    @_editorLinters.forEach(callback)
+    @editorLinters.forEach(callback)
 
   observeEditorLinters: (callback) ->
     @eachEditorLinter callback
-    @_emitter.on 'observe-editor-linters', callback
+    @emitter.on 'observe-editor-linters', callback
 
   deactivate: ->
-    @_subscriptions.dispose()
+    @subscriptions.dispose()
     @eachEditorLinter (linter) ->
       linter.destroy()
     @views.destroy()

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -132,7 +132,7 @@ class LinterViews
     for statusTile in @statusTiles
       statusTile.destroy()
 
-  _changeTab: (Tab) ->
+  changeTab: (Tab) ->
     if @bottomTabFile.active and Tab is 'file'
       @showPanel = not @showPanel
     else if @bottomTabProject.active and Tab is 'project'
@@ -149,12 +149,12 @@ class LinterViews
       @bottomTabProject.active = no
       @bottomTabFile.active = no
 
-  _removeBubble: ->
+  removeBubble: ->
     return unless @bubble
     @bubble.destroy()
     @bubble = null
 
-  _renderBubble: (message) ->
+  renderBubble: (message) ->
     bubble = document.createElement 'div'
     bubble.id = 'linter-inline'
     bubble.appendChild Message.fromMessage(message)
@@ -162,7 +162,7 @@ class LinterViews
       bubble.appendChild Message.fromMessage(trace, addPath: true)
     bubble
 
-  _renderPanel: ->
+  renderPanel: ->
     @panel.innerHTML = ''
     @removeMarkers()
     @removeBubble()
@@ -185,14 +185,14 @@ class LinterViews
     @updateBubble()
 
 
-  _removeMarkers: ->
+  removeMarkers: ->
     return unless @markers.length
     for marker in @markers
       try marker.destroy()
     @markers = []
 
   # This method is called in render, and classifies the messages according to scope
-  _extractMessages: (Gen, counts) ->
+  extractMessages: (Gen, counts) ->
     isProject = @scope is 'project'
     activeEditor = atom.workspace.getActiveTextEditor()
     activeFile = activeEditor?.getPath()

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -4,59 +4,59 @@ Message = require './views/message'
 
 class LinterViews
   constructor: (@linter) ->
-    @_showPanel = true # Altered by config observer in linter-plus
-    @_showBubble = true # Altered by the config observer in linter-plus
-    @_underlineIssues = true # Altered by config observer in linter-plus
+    @showPanel = true # Altered by config observer in linter-plus
+    @showBubble = true # Altered by the config observer in linter-plus
+    @underlineIssues = true # Altered by config observer in linter-plus
 
-    @_messages = new Set
-    @_markers = []
-    @_statusTiles = []
+    @messages = new Set
+    @markers = []
+    @statusTiles = []
 
-    @_bottomTabFile = new BottomTab()
-    @_bottomTabProject = new BottomTab()
-    @_panel = document.createElement 'div'
-    @_bubble = null
-    @_bottomStatus = new BottomStatus()
+    @bottomTabFile = new BottomTab()
+    @bottomTabProject = new BottomTab()
+    @panel = document.createElement 'div'
+    @bubble = null
+    @bottomStatus = new BottomStatus()
 
-    @_bottomTabFile.initialize("File", =>
-      @_changeTab('file')
+    @bottomTabFile.initialize("File", =>
+      @changeTab('file')
     )
-    @_bottomTabProject.initialize("Project", =>
-      @_changeTab('project')
+    @bottomTabProject.initialize("Project", =>
+      @changeTab('project')
     )
-    @_bottomStatus.initialize()
-    @_bottomStatus.addEventListener 'click', ->
+    @bottomStatus.initialize()
+    @bottomStatus.addEventListener 'click', ->
       atom.commands.dispatch atom.views.getView(atom.workspace), 'linter:next-error'
-    @_panelWorkspace = atom.workspace.addBottomPanel item: @_panel, visible: false
+    @panelWorkspace = atom.workspace.addBottomPanel item: @panel, visible: false
 
     # Set default tab to File
-    @_scope = 'file'
-    @_bottomTabFile.active = true
-    @_panel.id = 'linter-panel'
+    @scope = 'file'
+    @bottomTabFile.active = true
+    @panel.id = 'linter-panel'
 
   getMessages: ->
-    @_messages
+    @messages
 
 # consumed in views/panel
   setPanelVisibility: (Status) ->
     if Status
-      @_panelWorkspace.show() unless @_panelWorkspace.isVisible()
+      @panelWorkspace.show() unless @panelWorkspace.isVisible()
     else
-      @_panelWorkspace.hide() if @_panelWorkspace.isVisible()
+      @panelWorkspace.hide() if @panelWorkspace.isVisible()
 
   # Called in config observer of linter-plus.coffee
   setShowPanel: (showPanel) ->
     atom.config.set('linter.showErrorPanel', showPanel)
-    @_showPanel = showPanel
+    @showPanel = showPanel
     if showPanel
-      @_panel.removeAttribute('hidden')
+      @panel.removeAttribute('hidden')
     else
-      @_panel.setAttribute('hidden', true)
+      @panel.setAttribute('hidden', true)
 
   # Called in config observer of linter-plus.coffee
-  setShowBubble: (@_showBubble) ->
+  setShowBubble: (@showBubble) ->
 
-  setUnderlineIssues: (@_underlineIssues) ->
+  setUnderlineIssues: (@underlineIssues) ->
 
   setBubbleOpaque: ->
     bubble = document.getElementById('linter-inline')
@@ -75,84 +75,84 @@ class LinterViews
   # This message is called in editor-linter.coffee
   render: ->
     counts = {project: 0, file: 0}
-    @_messages.clear()
+    @messages.clear()
     @linter.eachEditorLinter (editorLinter) =>
-      @_extractMessages(editorLinter.getMessages(), counts)
+      @extractMessages(editorLinter.getMessages(), counts)
     @._extractMessages(@linter.getProjectMessages(), counts)
 
-    @_renderPanel()
-    @_bottomTabFile.count = counts.file
-    @_bottomTabProject.count = counts.project
-    @_bottomStatus.count = counts.project
+    @renderPanel()
+    @bottomTabFile.count = counts.file
+    @bottomTabProject.count = counts.project
+    @bottomStatus.count = counts.project
     hasActiveEditor = typeof atom.workspace.getActiveTextEditor() isnt 'undefined'
-    @_bottomTabFile.visibility = hasActiveEditor
-    @_bottomTabProject.visibility = hasActiveEditor
+    @bottomTabFile.visibility = hasActiveEditor
+    @bottomTabProject.visibility = hasActiveEditor
 
   # consumed in editor-linter, _renderPanel
   updateBubble: (point) ->
-    @_removeBubble()
-    return unless @_showBubble
-    return unless @_messages.size
+    @removeBubble()
+    return unless @showBubble
+    return unless @messages.size
     activeEditor = atom.workspace.getActiveTextEditor()
     return unless activeEditor?.getPath()
     point = point || activeEditor.getCursorBufferPosition()
-    try @_messages.forEach (message) =>
+    try @messages.forEach (message) =>
       return unless message.currentFile
       return unless message.range?.containsPoint point
-      @_bubble = activeEditor.markBufferRange([point, point], {invalidate: 'never'})
+      @bubble = activeEditor.markBufferRange([point, point], {invalidate: 'never'})
       activeEditor.decorateMarker(
-        @_bubble
+        @bubble
         {
           type: 'overlay',
           position: 'tail',
-          item: @_renderBubble(message)
+          item: @renderBubble(message)
         }
       )
       throw null
 
   # This method is called when we get the status-bar service
   attachBottom: (statusBar) ->
-    @_statusTiles.push statusBar.addLeftTile
-      item: @_bottomTabFile,
+    @statusTiles.push statusBar.addLeftTile
+      item: @bottomTabFile,
       priority: -1001
-    @_statusTiles.push statusBar.addLeftTile
-      item: @_bottomTabProject,
+    @statusTiles.push statusBar.addLeftTile
+      item: @bottomTabProject,
       priority: -1000
     statusIconPosition = atom.config.get('linter.statusIconPosition')
-    @_statusTiles.push statusBar["add#{statusIconPosition}Tile"]
-      item: @_bottomStatus,
+    @statusTiles.push statusBar["add#{statusIconPosition}Tile"]
+      item: @bottomStatus,
       priority: 999
 
   # this method is called on package deactivate
   destroy: ->
-    @_messages.clear()
-    @_removeMarkers()
-    @_panelWorkspace.destroy()
-    @_removeBubble()
-    for statusTile in @_statusTiles
+    @messages.clear()
+    @removeMarkers()
+    @panelWorkspace.destroy()
+    @removeBubble()
+    for statusTile in @statusTiles
       statusTile.destroy()
 
   _changeTab: (Tab) ->
-    if @_bottomTabFile.active and Tab is 'file'
-      @_showPanel = not @_showPanel
-    else if @_bottomTabProject.active and Tab is 'project'
-      @_showPanel = not @_showPanel
+    if @bottomTabFile.active and Tab is 'file'
+      @showPanel = not @showPanel
+    else if @bottomTabProject.active and Tab is 'project'
+      @showPanel = not @showPanel
     else
-      @_showPanel = true
-    @setShowPanel(@_showPanel)
-    if @_showPanel
-      @_scope = Tab
-      @_bottomTabProject.active = Tab is 'project'
-      @_bottomTabFile.active = Tab is 'file'
-      @_renderPanel()
+      @showPanel = true
+    @setShowPanel(@showPanel)
+    if @showPanel
+      @scope = Tab
+      @bottomTabProject.active = Tab is 'project'
+      @bottomTabFile.active = Tab is 'file'
+      @renderPanel()
     else
-      @_bottomTabProject.active = no
-      @_bottomTabFile.active = no
+      @bottomTabProject.active = no
+      @bottomTabFile.active = no
 
   _removeBubble: ->
-    return unless @_bubble
-    @_bubble.destroy()
-    @_bubble = null
+    return unless @bubble
+    @bubble.destroy()
+    @bubble = null
 
   _renderBubble: (message) ->
     bubble = document.createElement 'div'
@@ -163,37 +163,37 @@ class LinterViews
     bubble
 
   _renderPanel: ->
-    @_panel.innerHTML = ''
-    @_removeMarkers()
-    @_removeBubble()
-    if not @_messages.size
+    @panel.innerHTML = ''
+    @removeMarkers()
+    @removeBubble()
+    if not @messages.size
       return @setPanelVisibility(false)
     @setPanelVisibility(true)
     activeEditor = atom.workspace.getActiveTextEditor()
-    @_messages.forEach (message) =>
-      if @_scope is 'file' then return unless message.currentFile
-      if @_underlineIssues and message.currentFile and message.range #Add the decorations to the current TextEditor
-        @_markers.push marker = activeEditor.markBufferRange message.range, {invalidate: 'never'}
+    @messages.forEach (message) =>
+      if @scope is 'file' then return unless message.currentFile
+      if @underlineIssues and message.currentFile and message.range #Add the decorations to the current TextEditor
+        @markers.push marker = activeEditor.markBufferRange message.range, {invalidate: 'never'}
         activeEditor.decorateMarker(
           marker, type: 'line-number', class: "linter-highlight #{message.class}"
         )
         activeEditor.decorateMarker(
           marker, type: 'highlight', class: "linter-highlight #{message.class}"
         )
-      Element = Message.fromMessage(message, addPath: @_scope is 'project', cloneNode: true)
-      @_panel.appendChild Element
+      Element = Message.fromMessage(message, addPath: @scope is 'project', cloneNode: true)
+      @panel.appendChild Element
     @updateBubble()
 
 
   _removeMarkers: ->
-    return unless @_markers.length
-    for marker in @_markers
+    return unless @markers.length
+    for marker in @markers
       try marker.destroy()
-    @_markers = []
+    @markers = []
 
   # This method is called in render, and classifies the messages according to scope
   _extractMessages: (Gen, counts) ->
-    isProject = @_scope is 'project'
+    isProject = @scope is 'project'
     activeEditor = atom.workspace.getActiveTextEditor()
     activeFile = activeEditor?.getPath()
     Gen.forEach (Entry) =>
@@ -207,5 +207,5 @@ class LinterViews
         else
           counts.project++
           message.currentFile = false
-        @_messages.add message
+        @messages.add message
 module.exports = LinterViews

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -78,7 +78,7 @@ class LinterViews
     @messages.clear()
     @linter.eachEditorLinter (editorLinter) =>
       @extractMessages(editorLinter.getMessages(), counts)
-    @._extractMessages(@linter.getProjectMessages(), counts)
+    @extractMessages(@linter.getProjectMessages(), counts)
 
     @renderPanel()
     @bottomTabFile.count = counts.file

--- a/spec/legacy-spec.coffee
+++ b/spec/legacy-spec.coffee
@@ -3,19 +3,19 @@ describe 'legacy.coffee', ->
   legacyAdapter = require('../lib/legacy.coffee')
 
   it 'Adapts plain string `syntax` property', ->
-    clasicLinter = {
+    classicLinter = {
       syntax: 'source.js'
     }
 
-    adapted = legacyAdapter(clasicLinter)
+    adapted = legacyAdapter(classicLinter)
 
     expect(adapted.grammarScopes).toEqual(['source.js'])
 
   it 'Adapts array `syntax` property', ->
-    clasicLinter = {
+    classicLinter = {
       syntax: [ 'source.js' ]
     }
 
-    adapted = legacyAdapter(clasicLinter)
+    adapted = legacyAdapter(classicLinter)
 
     expect(adapted.grammarScopes).toEqual(['source.js'])


### PR DESCRIPTION
Linter Plus originally started out by copy/pasting code from my atom-hack and wrapping it in services, It's codebase was quite rough. So this is the Plan I followed to fix it.

- Prefix internal properties
- By doing the step above, we had to replace a lot of direct changes into other module's properties with observers and setter/getters
- Remove the prefixes added in first step

This is the last step of the Plan.

/cc @joefitzgerald