### PR TITLE
Multiline messages

### DIFF
--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -7,6 +7,7 @@ class Commands
       'linter:next-error': => @nextError()
       'linter:toggle': => @toggleLinter()
       'linter:set-bubble-transparent': => @setBubbleTransparent()
+      'linter:expand-multiline-messages': => @expandMultilineMessages()
       'linter:lint': => @lint()
 
     # Default values
@@ -17,6 +18,18 @@ class Commands
 
   setBubbleTransparent: ->
     @linter.views.setBubbleTransparent()
+
+  expandMultilineMessages: ->
+    for elem in document.getElementsByTagName 'linter-multiline-message'
+      elem.classList.add 'expanded'
+    document.addEventListener 'keyup', @collapseMultilineMessages
+    window.addEventListener 'blur', @collapseMultilineMessages
+
+  collapseMultilineMessages: ->
+    for elem in document.getElementsByTagName 'linter-multiline-message'
+      elem.classList.remove 'expanded'
+    document.removeEventListener 'keyup', @collapseMultilineMessages
+    window.removeEventListener 'blur', @collapseMultilineMessages
 
   lint: ->
     try

--- a/lib/views/message.coffee
+++ b/lib/views/message.coffee
@@ -1,4 +1,5 @@
 # This file is imported in views/panel
+MultilineElement = require './multiline'
 
 class Message extends HTMLElement
   initialize: (@message, @options) ->
@@ -41,6 +42,8 @@ class Message extends HTMLElement
           el.appendChild message.html.cloneNode(true)
         else
           el.appendChild message.html
+    else if message.multiline
+      el.appendChild MultilineElement.fromText message.text
     else
       el.textContent = message.text
     el

--- a/lib/views/multiline.coffee
+++ b/lib/views/multiline.coffee
@@ -1,0 +1,21 @@
+class MessageLine extends HTMLElement
+  setText: (@textContent) -> @
+
+LineElement =
+  document.registerElement('message-line', prototype: MessageLine.prototype)
+
+class Multiline extends HTMLElement
+  attachedCallback: ->
+    @tabIndex = 0
+    for line in @text.split(/\n/)
+      if line
+        @appendChild new LineElement().setText line
+
+  setText: (@text) -> @
+
+  @fromText: (text) ->
+    new MultilineElement().setText text
+
+module.exports = MultilineElement =
+  document.registerElement('linter-multiline-message', prototype: Multiline.prototype)
+module.exports.fromText = Multiline.fromText

--- a/lib/views/multiline.coffee
+++ b/lib/views/multiline.coffee
@@ -1,15 +1,11 @@
-class MessageLine extends HTMLElement
-  setText: (@textContent) -> @
-
-LineElement =
-  document.registerElement('message-line', prototype: MessageLine.prototype)
-
 class Multiline extends HTMLElement
   attachedCallback: ->
     @tabIndex = 0
     for line in @text.split(/\n/)
       if line
-        @appendChild new LineElement().setText line
+        el = document.createElement 'linter-message-line'
+        el.textContent = line
+        @appendChild el
 
   setText: (@text) -> @
 

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -24,18 +24,21 @@ linter-multiline-message {
   }
   line:not(:first-child) {
     display: none;
+    margin-left: calc(1em+1ch);
   }
-  line:first-child:not(:nth-last-of-type(1))::after {
-    content: "…";
-    margin-left: 1ch;
+  line:first-child:not(:nth-last-of-type(1))::before {
+    font-family: 'Octicons Regular';
+    content: @triangle-right;
+    display: inline-block;
+    width: calc(1em+1ch);
     padding: 0.1em 0.5em;
     pointer-events: auto;
     border-radius: 2px;
-    background-color: rgba(255,255,255,0.2);
+    text-align: center;
   }
   &:focus, &.expanded {
-    line::after {
-      visibility: hidden;
+    line:first-child:not(:nth-last-of-type(1))::before {
+      content: @triangle-down;
     }
     line:not(:first-child) {
       display: block;

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -2,11 +2,44 @@
 @import 'octicon-utf-codes';
 
 linter-message {
-  display: block;
+  display: flex;
+  align-items: flex-start;
   padding: 2px;
   font-size: @font-size;
   span {
     padding: 0 6px;
+  }
+  & > a {
+    align-self: flex-end;
+  }
+}
+
+linter-multiline-message {
+  display: block;
+  pointer-events: none;
+  -webkit-nav-index: 0;
+  line {
+    display: block;
+    white-space: pre;
+  }
+  line:not(:first-child) {
+    display: none;
+  }
+  line:first-child:not(:nth-last-of-type(1))::after {
+    content: "…";
+    margin-left: 1ch;
+    padding: 0.1em 0.5em;
+    pointer-events: auto;
+    border-radius: 2px;
+    background-color: rgba(255,255,255,0.2);
+  }
+  &:focus, &.expanded {
+    line::after {
+      visibility: hidden;
+    }
+    line:not(:first-child) {
+      display: block;
+    }
   }
 }
 

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -17,15 +17,15 @@ linter-message {
 linter-multiline-message {
   display: block;
   pointer-events: auto;
-  message-line {
+  linter-message-line {
     display: block;
     white-space: pre;
   }
-  message-line:not(:first-child) {
+  linter-message-line:not(:first-child) {
     display: none;
     margin-left: 1.1em;
   }
-  message-line:first-child:not(:nth-last-of-type(1))::before {
+  linter-message-line:first-child:not(:nth-last-of-type(1))::before {
     font-family: 'Octicons Regular';
     content: @triangle-right;
     display: inline-block;
@@ -35,10 +35,10 @@ linter-multiline-message {
     height: 1em;
   }
   &:focus, &.expanded {
-    message-line:first-child:not(:nth-last-of-type(1))::before {
+    linter-message-line:first-child:not(:nth-last-of-type(1))::before {
       content: @triangle-down;
     }
-    message-line:not(:first-child) {
+    linter-message-line:not(:first-child) {
       display: block;
     }
   }

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -3,44 +3,42 @@
 
 linter-message {
   display: flex;
-  align-items: flex-start;
+  align-items: flex-end;
   padding: 2px;
   font-size: @font-size;
   span {
     padding: 0 6px;
   }
-  & > a {
-    align-self: flex-end;
+  & > .badge {
+    align-self: flex-start;
   }
 }
 
 linter-multiline-message {
   display: block;
-  pointer-events: none;
-  -webkit-nav-index: 0;
-  line {
+  pointer-events: auto;
+  message-line {
     display: block;
     white-space: pre;
   }
-  line:not(:first-child) {
+  message-line:not(:first-child) {
     display: none;
-    margin-left: calc(1em+1ch);
+    margin-left: 1.1em;
   }
-  line:first-child:not(:nth-last-of-type(1))::before {
+  message-line:first-child:not(:nth-last-of-type(1))::before {
     font-family: 'Octicons Regular';
     content: @triangle-right;
     display: inline-block;
-    width: calc(1em+1ch);
-    padding: 0.1em 0.5em;
-    pointer-events: auto;
-    border-radius: 2px;
+    width: 1em;
+    margin-right: 0.1em;
     text-align: center;
+    height: 1em;
   }
   &:focus, &.expanded {
-    line:first-child:not(:nth-last-of-type(1))::before {
+    message-line:first-child:not(:nth-last-of-type(1))::before {
       content: @triangle-down;
     }
-    line:not(:first-child) {
+    message-line:not(:first-child) {
       display: block;
     }
   }
@@ -85,9 +83,6 @@ linter-multiline-message {
   a {
     color: @linter-inline-link;
     margin-right: 4px;
-  }
-  .badge {
-    margin-top: -2px;
   }
 }
 


### PR DESCRIPTION
Support for multiline messages

For reasons of backwards-compatibility, multiline messages need to have `multiline: true` field set. With `multiline: true`, `text` argument will be treated with `white-space: pre`. If `html` is set, it takes precedence over both (since I'm not entirely convinced if "multiline html" even makes sense).

Multiline messages are collapsed to show only first line by default. It is possible to expand those individually with mouse click (at any given moment, only one message can be expanded this way), or all with `linter:expand-multiline-messages` command, preferably bound to a key (`ctrl` or `shift`, for example).

For styling, there are two options I could think of. Current implementation looks something like this:

![Collapsed](https://cloud.githubusercontent.com/assets/7275622/8391392/512d10ca-1ccb-11e5-93fb-2764c778922c.png)
Collapsed

![Panel message expanded](https://cloud.githubusercontent.com/assets/7275622/8391397/72d07e24-1ccb-11e5-9301-938df8932245.png)
Panel message expanded

![Tooltip message expanded](https://cloud.githubusercontent.com/assets/7275622/8391402/92dc2dda-1ccb-11e5-882f-7b0f73141db0.png)
Tooltip message expanded

![All messages expanded](https://cloud.githubusercontent.com/assets/7275622/8391406/a8960696-1ccb-11e5-8657-3e2a97617865.png)
All messages expanded

I've also considered an option to put marker of "expandability" at the end of first line, e.g.
![Tooltip message expanded (alternative)](https://cloud.githubusercontent.com/assets/7275622/8391418/114eb886-1ccc-11e5-8190-fb25959b1262.png)
Tooltip message expanded (alternative)

I think first version is less ambiguous, but I'd like to hear other opinions on the subject.

If you want to test this, currently this is used by `linter` branch on https://github.com/atom-haskell/haskell-ghc-mod (bear in mind one also needs `language-haskell` and `ide-haskell` installed, and `ghc-mod` executable available on `PATH`)