### PR TITLE
Refactor Views codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Upcoming
+
+* Fix a bug when Error Panel won't collapse even when there's no errors with File as Active Tab
+* Speed Improvements
+
 # 1.1.0
 
 * Add support for collapsible messages

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -8,10 +8,7 @@ class EditorLinter
     @inProgress = false
     @inProgressFly = false
 
-    @lineForMessages = 0 # It's used to compare if the user has changed line so we can updateLineMessages
-
     if @editor is atom.workspace.getActiveTextEditor()
-      @lineForMessages = @editor.getCursorBufferPosition()?.row
       @linter.views.updateLineMessages(true)
 
     @emitter = new Emitter
@@ -21,11 +18,9 @@ class EditorLinter
       @editor.onDidSave => @lint(false)
     )
     @subscriptions.add(
-      @editor.onDidChangeCursorPosition ({newBufferPosition}) =>
-        lineForMessages = newBufferPosition.row
-        if lineForMessages isnt @lineForMessages
+      @editor.onDidChangeCursorPosition ({oldBufferPosition, newBufferPosition}) =>
+        if newBufferPosition.row isnt oldBufferPosition.row
           @linter.views.updateLineMessages(true)
-          @lineForMessages = lineForMessages
         @linter.views.updateBubble(newBufferPosition)
     )
     @subscriptions.add(

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -8,7 +8,7 @@ class EditorLinter
     @inProgress = false
     @inProgressFly = false
 
-    @lineForMessages = 0 # Used to tell if the user has changed line so we can updateLineMessages
+    @lineForMessages = 0 # It's used to compare if the user has changed line so we can updateLineMessages
 
     if @editor is atom.workspace.getActiveTextEditor()
       @lineForMessages = @editor.getCursorBufferPosition()?.row

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -8,8 +8,11 @@ class EditorLinter
     @inProgress = false
     @inProgressFly = false
 
+    @lineForMessages = 0 # Used to tell if the user has changed line so we can updateLineMessages
+
     if @editor is atom.workspace.getActiveTextEditor()
-      @linter.views.updateLineMessages(@editor.getCursorBufferPosition()?.row, true)
+      @lineForMessages = @editor.getCursorBufferPosition()?.row
+      @linter.views.updateLineMessages(true)
 
     @emitter = new Emitter
     @subscriptions = new CompositeDisposable
@@ -19,7 +22,10 @@ class EditorLinter
     )
     @subscriptions.add(
       @editor.onDidChangeCursorPosition ({newBufferPosition}) =>
-        @linter.views.updateLineMessages(newBufferPosition.row, true)
+        lineForMessages = newBufferPosition.row
+        if lineForMessages isnt @lineForMessages
+          @linter.views.updateLineMessages(true)
+          @lineForMessages = lineForMessages
         @linter.views.updateBubble(newBufferPosition)
     )
     @subscriptions.add(

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -9,7 +9,7 @@ class EditorLinter
     @inProgressFly = false
 
     if @editor is atom.workspace.getActiveTextEditor()
-      @linter.views.updateCurrentLine @editor.getCursorBufferPosition()?.row
+      @linter.views.updateLineMessages @editor.getCursorBufferPosition()?.row
 
     @emitter = new Emitter
     @subscriptions = new CompositeDisposable
@@ -19,7 +19,7 @@ class EditorLinter
     )
     @subscriptions.add(
       @editor.onDidChangeCursorPosition ({newBufferPosition}) =>
-        @linter.views.updateCurrentLine(newBufferPosition.row)
+        @linter.views.updateLineMessages(newBufferPosition.row)
         @linter.views.updateBubble(newBufferPosition)
     )
     @subscriptions.add(

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -9,7 +9,7 @@ class EditorLinter
     @inProgressFly = false
 
     if @editor is atom.workspace.getActiveTextEditor()
-      @linter.views.updateLineMessages @editor.getCursorBufferPosition()?.row
+      @linter.views.updateLineMessages(@editor.getCursorBufferPosition()?.row, true)
 
     @emitter = new Emitter
     @subscriptions = new CompositeDisposable
@@ -19,7 +19,7 @@ class EditorLinter
     )
     @subscriptions.add(
       @editor.onDidChangeCursorPosition ({newBufferPosition}) =>
-        @linter.views.updateLineMessages(newBufferPosition.row)
+        @linter.views.updateLineMessages(newBufferPosition.row, true)
         @linter.views.updateBubble(newBufferPosition)
     )
     @subscriptions.add(

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -32,14 +32,14 @@ class Linter
     @subscriptions.add atom.workspace.onDidChangeActivePaneItem =>
       @commands.lint()
 
-    ignoreUpdateTabs = true
+    ignoreTabUpdates = true
     @subscriptions.add atom.config.observe 'linter.showErrorTabLine', =>
-      @views.updateTabs() unless ignoreUpdateTabs
+      @views.updateTabs() unless ignoreTabUpdates
     @subscriptions.add atom.config.observe 'linter.showErrorTabFile', =>
-      @views.updateTabs() unless ignoreUpdateTabs
+      @views.updateTabs() unless ignoreTabUpdates
     @subscriptions.add atom.config.observe 'linter.showErrorTabProject', =>
-      @views.updateTabs() unless ignoreUpdateTabs
-    ignoreUpdateTabs = false
+      @views.updateTabs() unless ignoreTabUpdates
+    ignoreTabUpdates = false
 
     @subscriptions.add atom.workspace.observeTextEditors (editor) =>
       currentEditorLinter = new EditorLinter @, editor

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -25,19 +25,21 @@ class Linter
       @views.setShowPanel(showPanel)
     @subscriptions.add atom.config.observe 'linter.underlineIssues', (underlineIssues) =>
       @views.setUnderlineIssues(underlineIssues)
-    # Todo: When observing that showErrorTabLine updateTabs() is called thrice, resulting in redundant updates
-    @subscriptions.add atom.config.observe 'linter.showErrorTabLine', =>
-      @views.updateTabs()
-    @subscriptions.add atom.config.observe 'linter.showErrorTabFile', =>
-      @views.updateTabs()
-    @subscriptions.add atom.config.observe 'linter.showErrorTabProject', =>
-      @views.updateTabs()
     @subscriptions.add atom.config.observe 'linter.lintOnFly', (value) =>
       @lintOnFly = value
     @subscriptions.add atom.project.onDidChangePaths =>
       @commands.lint()
     @subscriptions.add atom.workspace.onDidChangeActivePaneItem =>
       @commands.lint()
+
+    ignoreUpdateTabs = true
+    @subscriptions.add atom.config.observe 'linter.showErrorTabLine', =>
+      @views.updateTabs() unles ignoreUpdateTabs
+    @subscriptions.add atom.config.observe 'linter.showErrorTabFile', =>
+      @views.updateTabs() unless ignoreUpdateTabs
+    @subscriptions.add atom.config.observe 'linter.showErrorTabProject', =>
+      @views.updateTabs() unless ignoreUpdateTabs
+    ignoreUpdateTabs = false
 
     @subscriptions.add atom.workspace.observeTextEditors (editor) =>
       currentEditorLinter = new EditorLinter @, editor

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -25,6 +25,12 @@ class Linter
       @views.setShowPanel(showPanel)
     @subscriptions.add atom.config.observe 'linter.underlineIssues', (underlineIssues) =>
       @views.setUnderlineIssues(underlineIssues)
+    @subscriptions.add atom.config.observe 'linter.showErrorTabLine', =>
+      @views.updateTabs()
+    @subscriptions.add atom.config.observe 'linter.showErrorTabFile', =>
+      @views.updateTabs()
+    @subscriptions.add atom.config.observe 'linter.showErrorTabProject', =>
+      @views.updateTabs()
     @subscriptions.add atom.config.observe 'linter.lintOnFly', (value) =>
       @lintOnFly = value
     @subscriptions.add atom.project.onDidChangePaths =>

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -34,7 +34,7 @@ class Linter
 
     ignoreUpdateTabs = true
     @subscriptions.add atom.config.observe 'linter.showErrorTabLine', =>
-      @views.updateTabs() unles ignoreUpdateTabs
+      @views.updateTabs() unless ignoreUpdateTabs
     @subscriptions.add atom.config.observe 'linter.showErrorTabFile', =>
       @views.updateTabs() unless ignoreUpdateTabs
     @subscriptions.add atom.config.observe 'linter.showErrorTabProject', =>

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -25,6 +25,7 @@ class Linter
       @views.setShowPanel(showPanel)
     @subscriptions.add atom.config.observe 'linter.underlineIssues', (underlineIssues) =>
       @views.setUnderlineIssues(underlineIssues)
+    # Todo: When observing that showErrorTabLine updateTabs() is called thrice, resulting in redundant updates
     @subscriptions.add atom.config.observe 'linter.showErrorTabLine', =>
       @views.updateTabs()
     @subscriptions.add atom.config.observe 'linter.showErrorTabFile', =>

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -32,14 +32,12 @@ class Linter
     @subscriptions.add atom.workspace.onDidChangeActivePaneItem =>
       @commands.lint()
 
-    ignoreTabUpdates = true
-    @subscriptions.add atom.config.observe 'linter.showErrorTabLine', =>
-      @views.updateTabs() unless ignoreTabUpdates
-    @subscriptions.add atom.config.observe 'linter.showErrorTabFile', =>
-      @views.updateTabs() unless ignoreTabUpdates
-    @subscriptions.add atom.config.observe 'linter.showErrorTabProject', =>
-      @views.updateTabs() unless ignoreTabUpdates
-    ignoreTabUpdates = false
+    @subscriptions.add atom.config.onDidChange 'linter.showErrorTabLine', =>
+      @views.updateTabs()
+    @subscriptions.add atom.config.onDidChange 'linter.showErrorTabFile', =>
+      @views.updateTabs()
+    @subscriptions.add atom.config.onDidChange 'linter.showErrorTabProject', =>
+      @views.updateTabs()
 
     @subscriptions.add atom.workspace.observeTextEditors (editor) =>
       currentEditorLinter = new EditorLinter @, editor

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -134,14 +134,14 @@ class LinterViews
       )
       throw null
 
-  updateLineMessages: (line, shouldRender = false) ->
-    return if @currentLine is line
+  updateLineMessages: (shouldRender = false) ->
     return unless @tabs['Line'].visibility
-    @currentLine = line
     @lineMessages.clear()
-    if @linter.getActiveEditorLinter()
+    activeTextEditor = atom.workspace.getActiveTextEditor()
+    if activeTextEditor
+      currentLine = activeTextEditor.getCursorBufferPosition()?.row
       @messages.forEach (message) =>
-        if message.currentFile and message.range?.intersectsRow @currentLine
+        if message.currentFile and message.range?.intersectsRow currentLine
           @lineMessages.add message
       @tabs['Line'].count = @lineMessages.size
     if shouldRender then @renderPanelMessages()

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -97,6 +97,11 @@ class LinterViews
     @tabs.get('project').count = counts.project
     @bottomStatus.count = counts.project
 
+  updateTabs: ->
+    visible = @getVisibleTabs()
+    @tabs.forEach (tab, key) ->
+      tab.visibility = visible.has(key)
+
   # consumed in editor-linter, _renderPanel
   updateBubble: (point) ->
     @removeBubble()

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -204,6 +204,14 @@ class LinterViews
       @panel.appendChild Element
     @updateBubble()
 
+  renderPanelMessages: ->
+    messages = null
+    if @tabs['Line'].active
+      messages = @lineMessages
+    else
+      messages = @messages
+    return @setPanelVisibility(false) unless messages.size
+
   removeMarkers: ->
     return unless @markers.length
     for marker in @markers

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -179,15 +179,11 @@ class LinterViews
     bubble
 
   renderPanel: ->
-    @panel.innerHTML = ''
     @removeMarkers()
     @removeBubble()
-    if not @messages.size
-      return @setPanelVisibility(false)
-    @setPanelVisibility(true)
     activeEditor = atom.workspace.getActiveTextEditor()
     @messages.forEach (message) =>
-      if @scope is 'File' then return unless message.currentFile
+      return if @scope isnt 'Project' and not message.currentFile
       if message.currentFile and message.range #Add the decorations to the current TextEditor
         @markers.push marker = activeEditor.markBufferRange message.range, {invalidate: 'never'}
         activeEditor.decorateMarker(
@@ -196,12 +192,6 @@ class LinterViews
         if @underlineIssues then activeEditor.decorateMarker(
           marker, type: 'highlight', class: "linter-highlight #{message.class}"
         )
-
-      if @scope is 'Line'
-        return if @lineMessages.has(message)
-
-      Element = Message.fromMessage(message, addPath: @scope is 'Project', cloneNode: true)
-      @panel.appendChild Element
     @updateBubble()
 
   renderPanelMessages: ->
@@ -211,6 +201,7 @@ class LinterViews
     else
       messages = @messages
     return @setPanelVisibility(false) unless messages.size
+    @setPanelVisibility(true)
     @panel.innerHTML = ''
     messages.forEach (message) =>
       return if @scope isnt 'Project' and not message.currentFile

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -125,14 +125,9 @@ class LinterViews
       )
       throw null
 
-  updateCurrentLine: (line) ->
-    if @currentLine isnt line
-      @currentLine = line
-      @updateLineMessages()
-      @renderPanel()
-
-
-  updateLineMessages: ->
+  updateLineMessages: (line) ->
+    return if @currentLine is line
+    @currentLine = line
     activeEditor = atom.workspace.getActiveTextEditor()
     @linter.eachEditorLinter (editorLinter) =>
       return unless editorLinter.editor is activeEditor
@@ -142,6 +137,7 @@ class LinterViews
         if message.currentFile and message.range?.intersectsRow @currentLine
           @lineMessages.push message
       @tabs['Line'].count = @lineMessages.length
+    @renderPanel()
 
   # This method is called when we get the status-bar service
   attachBottom: (statusBar) ->

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -31,7 +31,7 @@ class LinterViews
     @panelWorkspace = atom.workspace.addBottomPanel item: @panel, visible: false
 
     # Set default tab
-    visibleTabs = @getVisibleTabKeys()
+    visibleTabs = @getVisibleTabs()
 
     @scope = atom.config.get('linter.defaultErrorTab', 'File')?.toLowerCase()
     if not visibleTabs.has(@scope)
@@ -181,7 +181,7 @@ class LinterViews
   getActiveTab: ->
     @tabs.entries().find (tab) -> tab.active
 
-  getVisibleTabKeys: ->
+  getVisibleTabs: ->
     toReturn = new Set
     toReturn.add 'line' if atom.config.get('linter.showErrorTabLine')
     toReturn.add 'file' if atom.config.get('linter.showErrorTabFile')

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -142,7 +142,7 @@ class LinterViews
       @messages.forEach (message) =>
         if message.currentFile and message.range?.intersectsRow @currentLine
           @lineMessages.add message
-      @tabs['Line'].count = @lineMessages.length
+      @tabs['Line'].count = @lineMessages.size
     if shouldRender then @renderPanelMessages()
 
   # This method is called when we get the status-bar service

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -9,8 +9,8 @@ class LinterViews
     @underlineIssues = true # Altered by config observer in linter-plus
 
     @messages = new Set
+    @lineMessages = new Set
     @markers = []
-    @lineMessages = []
     @statusTiles = []
 
     @tabs = {} # Object has methods that we need to perform certain operations, map won't be a good fit
@@ -129,11 +129,11 @@ class LinterViews
     return if @currentLine is line
     return unless @tabs['Line'].visibility
     @currentLine = line
-    @lineMessages = []
+    @lineMessages.clear()
     if @linter.getActiveEditorLinter()
       @messages.forEach (message) =>
         if message.currentFile and message.range?.intersectsRow @currentLine
-          @lineMessages.push message
+          @lineMessages.add message
       @tabs['Line'].count = @lineMessages.length
     if shouldRender then @renderPanel()
 
@@ -198,7 +198,7 @@ class LinterViews
         )
 
       if @scope is 'Line'
-        return if @lineMessages.indexOf(message) is -1
+        return if @lineMessages.has(message)
 
       Element = Message.fromMessage(message, addPath: @scope is 'Project', cloneNode: true)
       @panel.appendChild Element

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -95,7 +95,7 @@ class LinterViews
     for key, tab of @tabs # for...of (key, value)
       tab.classList.remove('first')
       tab.classList.remove('last')
-      tab.visibility = visible.has(key)
+      tab.visibility = visible.indexOf(key) isnt -1
 
   # consumed in editor-linter, _renderPanel
   updateBubble: (point) ->
@@ -174,10 +174,10 @@ class LinterViews
     @setShowPanel @showPanel
 
   getVisibleTabs: ->
-    toReturn = new Set
-    toReturn.add 'line' if atom.config.get('linter.showErrorTabLine')
-    toReturn.add 'file' if atom.config.get('linter.showErrorTabFile')
-    toReturn.add 'project' if atom.config.get('linter.showErrorTabProject')
+    toReturn = []
+    toReturn.push 'line' if atom.config.get('linter.showErrorTabLine')
+    toReturn.push 'file' if atom.config.get('linter.showErrorTabFile')
+    toReturn.push 'project' if atom.config.get('linter.showErrorTabProject')
     toReturn
 
   removeBubble: ->

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -156,6 +156,7 @@ class LinterViews
       priority: -999
 
   changeTab: (Tab) ->
+    atom.config.set('linter.defaultErrorTab', Tab)
     @showPanel = @scope isnt Tab
     if not @showPanel
       for key, tab of @tabs

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -13,10 +13,10 @@ class LinterViews
     @markers = []
     @statusTiles = []
 
-    @tabs = {}
-    @tabs['Line'] = new BottomTab()
-    @tabs['File'] = new BottomTab()
-    @tabs['Project'] = new BottomTab()
+    @tabs =
+      Line: new BottomTab()
+      File: new BottomTab()
+      Project: new BottomTab()
 
     @panel = document.createElement 'div'
     @bubble = null

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -100,6 +100,8 @@ class LinterViews
   updateTabs: ->
     visible = @getVisibleTabs()
     @tabs.forEach (tab, key) ->
+      tab.classList.remove('first')
+      tab.classList.remove('last')
       tab.visibility = visible.has(key)
 
   # consumed in editor-linter, _renderPanel

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -95,13 +95,19 @@ class LinterViews
   updateTabs: ->
     first = null
     last = null
+    foundActive = false
+    firstLabel = null
     for key, tab of @tabs # for...of (key, value)
       tab.classList.remove('first')
       tab.classList.remove('last')
       tab.visibility = atom.config.get("linter.showErrorTab#{key}")
       if tab.visibility
+        foundActive = foundActive || tab.active
         if first then last = tab
-        else first = tab
+        else
+          first = tab
+          firstLabel = key
+    @changeTab(firstLabel) if first and not foundActive
     first.classList.add('first') if first
     last.classList.add('last') if last
 

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -128,8 +128,7 @@ class LinterViews
     return if @currentLine is line
     @currentLine = line
     @lineMessages = []
-    activeEditorLinter = @linter.getActiveEditorLinter()
-    if activeEditorLinter
+    if @linter.getActiveEditorLinter()
       @messages.forEach (message) =>
         if message.currentFile and message.range?.intersectsRow @currentLine
           @lineMessages.push message

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -4,16 +4,16 @@ Message = require './views/message'
 
 class LinterViews
   constructor: (@linter) ->
-    @showPanel = true # Altered by config observer in linter-plus
-    @showBubble = true # Altered by the config observer in linter-plus
-    @underlineIssues = true # Altered by config observer in linter-plus
+    @showPanel = true
+    @showBubble = true
+    @underlineIssues = true
 
     @messages = new Set
     @lineMessages = new Set
     @markers = []
     @statusTiles = []
 
-    @tabs = {} # Object has methods that we need to perform certain operations, map won't be a good fit
+    @tabs = {}
     @tabs['Line'] = new BottomTab()
     @tabs['File'] = new BottomTab()
     @tabs['Project'] = new BottomTab()

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -12,7 +12,7 @@ class LinterViews
     @markers = []
     @statusTiles = []
 
-    @tabs = [] # Array has methods that we need to perform certain operations, map won't be a good fit
+    @tabs = {} # Object has methods that we need to perform certain operations, map won't be a good fit
     @tabs['line'] = new BottomTab()
     @tabs['file'] = new BottomTab()
     @tabs['project'] = new BottomTab()
@@ -31,7 +31,7 @@ class LinterViews
     @panelWorkspace = atom.workspace.addBottomPanel item: @panel, visible: false
 
     @scope = atom.config.get('linter.defaultErrorTab').toLowerCase()
-    @tabs.forEach (tab, key) =>
+    for key, tab of @tabs
       tab.active = @scope is key
 
     @panel.id = 'linter-panel'
@@ -92,7 +92,7 @@ class LinterViews
 
   updateTabs: ->
     visible = @getVisibleTabs()
-    @tabs.forEach (tab, key) ->
+    for key, tab of @tabs # for...of (key, value)
       tab.classList.remove('first')
       tab.classList.remove('last')
       tab.visibility = visible.has(key)

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -149,7 +149,7 @@ class LinterViews
     statusIconPosition = atom.config.get('linter.statusIconPosition')
     @statusTiles.push statusBar["add#{statusIconPosition}Tile"]
       item: @bottomStatus,
-      priority: 999
+      priority: -999
 
   # this method is called on package deactivate
   destroy: ->
@@ -208,7 +208,6 @@ class LinterViews
         return if @lineMessages.indexOf(message) is -1
 
       Element = Message.fromMessage(message, addPath: @scope is 'Project', cloneNode: true)
-
       @panel.appendChild Element
     @updateBubble()
 

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -194,7 +194,7 @@ class LinterViews
     @setPanelVisibility(true)
     activeEditor = atom.workspace.getActiveTextEditor()
     @messages.forEach (message) =>
-      if @scope is 'file' then return unless message.currentFile
+      if @scope is 'File' then return unless message.currentFile
       if message.currentFile and message.range #Add the decorations to the current TextEditor
         @markers.push marker = activeEditor.markBufferRange message.range, {invalidate: 'never'}
         activeEditor.decorateMarker(
@@ -204,10 +204,10 @@ class LinterViews
           marker, type: 'highlight', class: "linter-highlight #{message.class}"
         )
 
-      if @scope is 'line'
+      if @scope is 'Line'
         return if @lineMessages.indexOf(message) is -1
 
-      Element = Message.fromMessage(message, addPath: @scope is 'project', cloneNode: true)
+      Element = Message.fromMessage(message, addPath: @scope is 'Project', cloneNode: true)
 
       @panel.appendChild Element
     @updateBubble()
@@ -221,7 +221,7 @@ class LinterViews
 
   # This method is called in render, and classifies the messages according to scope
   extractMessages: (Gen, counts) ->
-    isProject = @scope is 'project'
+    isProject = @scope is 'Project'
     activeEditor = atom.workspace.getActiveTextEditor()
     activeFile = activeEditor?.getPath()
     Gen.forEach (Entry) =>

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -85,7 +85,8 @@ class LinterViews
     @extractMessages(@linter.getProjectMessages(), counts)
 
     @updateLineMessages()
-    @renderPanel()
+    @updateBubble()
+    @renderPanelMarkers()
     @renderPanelMessages()
     @tabs['File'].count = counts.file
     @tabs['Project'].count = counts.project
@@ -179,9 +180,8 @@ class LinterViews
       bubble.appendChild Message.fromMessage(trace, addPath: true)
     bubble
 
-  renderPanel: ->
+  renderPanelMarkers: ->
     @removeMarkers()
-    @removeBubble()
     activeEditor = atom.workspace.getActiveTextEditor()
     @messages.forEach (message) =>
       return if @scope isnt 'Project' and not message.currentFile
@@ -193,7 +193,6 @@ class LinterViews
         if @underlineIssues then activeEditor.decorateMarker(
           marker, type: 'highlight', class: "linter-highlight #{message.class}"
         )
-    @updateBubble()
 
   renderPanelMessages: ->
     messages = null

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -21,9 +21,9 @@ class LinterViews
     @bubble = null
     @bottomStatus = new BottomStatus()
 
-    @tabs['Line'].initialize 'Line', => @changeTab('line')
-    @tabs['File'].initialize 'File', => @changeTab('file')
-    @tabs['Project'].initialize 'Project', => @changeTab('project')
+    @tabs['Line'].initialize 'Line', => @changeTab('Line')
+    @tabs['File'].initialize 'File', => @changeTab('File')
+    @tabs['Project'].initialize 'Project', => @changeTab('Project')
 
     @bottomStatus.initialize()
     @bottomStatus.addEventListener 'click', ->
@@ -161,11 +161,10 @@ class LinterViews
       statusTile.destroy()
 
   changeTab: (Tab) ->
-    if @scope is Tab.toLowerCase()
-      @showPanel = not @showPanel
+    @showPanel = @scope is Tab
+    if @showPanel
       @tabs.forEach (tab)-> tab.active = false
     else
-      @showPanel = true
       @scope = Tab
       @tabs.forEach (tab, key) -> tab.active = Tab is key
       @renderPanel()

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -126,6 +126,7 @@ class LinterViews
 
   updateLineMessages: (line, shouldRender = false) ->
     return if @currentLine is line
+    return unless @tabs['Line'].visibility
     @currentLine = line
     @lineMessages = []
     if @linter.getActiveEditorLinter()

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -34,7 +34,7 @@ class LinterViews
     visibleTabs = @getVisibleTabKeys()
 
     @scope = atom.config.get('linter.defaultErrorTab', 'File')?.toLowerCase()
-    if visibleTabs.indexOf(@scope) is -1
+    if not visibleTabs.has(@scope)
       @scope = visibleTabs[0]
 
     @tabs.forEach (tab, key) =>
@@ -46,7 +46,7 @@ class LinterViews
   getMessages: ->
     @messages
 
-# consumed in views/panel
+  # consumed in views/panel
   setPanelVisibility: (Status) ->
     if Status
       @panelWorkspace.show() unless @panelWorkspace.isVisible()
@@ -194,11 +194,11 @@ class LinterViews
     @tabs.entries().find (tab) -> tab.active
 
   getVisibleTabKeys: ->
-    return [
-      'line'    if atom.config.get('linter.showErrorTabLine')
-      'file'    if atom.config.get('linter.showErrorTabFile')
-      'project' if atom.config.get('linter.showErrorTabProject')
-    ].filter (key) -> key
+    toReturn = new Set
+    toReturn.add 'line' if atom.config.get('linter.showErrorTabLine')
+    toReturn.add 'file' if atom.config.get('linter.showErrorTabFile')
+    toReturn.add 'project' if atom.config.get('linter.showErrorTabProject')
+    toReturn
 
   removeBubble: ->
     return unless @bubble

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -30,7 +30,7 @@ class LinterViews
       atom.commands.dispatch atom.views.getView(atom.workspace), 'linter:next-error'
     @panelWorkspace = atom.workspace.addBottomPanel item: @panel, visible: false
 
-    @scope = atom.config.get('linter.defaultErrorTab').toLowerCase()
+    @scope = atom.config.get('linter.defaultErrorTab')
     for key, tab of @tabs
       tab.active = @scope is key
 
@@ -161,12 +161,14 @@ class LinterViews
       statusTile.destroy()
 
   changeTab: (Tab) ->
-    @showPanel = @scope is Tab
-    if @showPanel
-      @tabs.forEach (tab)-> tab.active = false
+    @showPanel = @scope isnt Tab
+    if not @showPanel
+      for key, tab of @tabs
+        tab.active = false
     else
       @scope = Tab
-      @tabs.forEach (tab, key) -> tab.active = Tab is key
+      for key, tab of @tabs
+        tab.active = Tab is key
       @renderPanel()
     @setShowPanel @showPanel
 

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -84,7 +84,6 @@ class LinterViews
     @extractMessages(@linter.getProjectMessages(), counts)
 
     @updateLineMessages()
-
     @renderPanel()
     @tabs['File'].count = counts.file
     @tabs['Project'].count = counts.project
@@ -125,19 +124,17 @@ class LinterViews
       )
       throw null
 
-  updateLineMessages: (line) ->
+  updateLineMessages: (line, shouldRender = false) ->
     return if @currentLine is line
     @currentLine = line
-    activeEditor = atom.workspace.getActiveTextEditor()
-    @linter.eachEditorLinter (editorLinter) =>
-      return unless editorLinter.editor is activeEditor
-
-      @lineMessages = []
+    @lineMessages = []
+    activeEditorLinter = @linter.getActiveEditorLinter()
+    if activeEditorLinter
       @messages.forEach (message) =>
         if message.currentFile and message.range?.intersectsRow @currentLine
           @lineMessages.push message
       @tabs['Line'].count = @lineMessages.length
-    @renderPanel()
+    if shouldRender then @renderPanel()
 
   # This method is called when we get the status-bar service
   attachBottom: (statusBar) ->

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -211,6 +211,11 @@ class LinterViews
     else
       messages = @messages
     return @setPanelVisibility(false) unless messages.size
+    @panel.innerHTML = ''
+    messages.forEach (message) =>
+      return if @scope isnt 'Project' and not message.currentFile
+      Element = Message.fromMessage(message, addPath: @scope is 'Project', cloneNode: true)
+      @panel.appendChild Element
 
   removeMarkers: ->
     return unless @markers.length

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -22,10 +22,6 @@ class LinterViews
     @bubble = null
     @bottomStatus = new BottomStatus()
 
-    @tabs['Line'].initialize 'Line', => @changeTab('Line')
-    @tabs['File'].initialize 'File', => @changeTab('File')
-    @tabs['Project'].initialize 'Project', => @changeTab('Project')
-
     @bottomStatus.initialize()
     @bottomStatus.addEventListener 'click', ->
       atom.commands.dispatch atom.views.getView(atom.workspace), 'linter:next-error'
@@ -33,6 +29,8 @@ class LinterViews
 
     @scope = atom.config.get('linter.defaultErrorTab')
     for key, tab of @tabs
+      do (key, tab) =>
+        tab.initialize key, => @changeTab(key)
       tab.active = @scope is key
 
     @panel.id = 'linter-panel'

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -151,15 +151,6 @@ class LinterViews
       item: @bottomStatus,
       priority: -999
 
-  # this method is called on package deactivate
-  destroy: ->
-    @messages.clear()
-    @removeMarkers()
-    @panelWorkspace.destroy()
-    @removeBubble()
-    for statusTile in @statusTiles
-      statusTile.destroy()
-
   changeTab: (Tab) ->
     @showPanel = @scope isnt Tab
     if not @showPanel
@@ -235,5 +226,14 @@ class LinterViews
           counts.project++
           message.currentFile = false
         @messages.add message
+
+  # this method is called on package deactivate
+  destroy: ->
+    @messages.clear()
+    @removeMarkers()
+    @panelWorkspace.destroy()
+    @removeBubble()
+    for statusTile in @statusTiles
+      statusTile.destroy()
 
 module.exports = LinterViews

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -174,12 +174,6 @@ class LinterViews
     @setShowPanel @showPanel
 
   # TODO: Remove me and use @scope instead
-  getActiveTabKey: ->
-    activeKey = null
-    @tabs.forEach (tab, key) -> activeKey = key if tab.active
-    return activeKey
-
-  # TODO: Remove me and use @scope instead
   getActiveTab: ->
     @tabs.find (tab) -> tab.active
 

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -173,10 +173,6 @@ class LinterViews
       @renderPanel()
     @setShowPanel @showPanel
 
-  # TODO: Remove me and use @scope instead
-  getActiveTab: ->
-    @tabs.find (tab) -> tab.active
-
   getVisibleTabs: ->
     toReturn = new Set
     toReturn.add 'line' if atom.config.get('linter.showErrorTabLine')

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -96,18 +96,6 @@ class LinterViews
     @tabs.get('file').count = counts.file
     @tabs.get('project').count = counts.project
     @bottomStatus.count = counts.project
-    hasActiveEditor = typeof atom.workspace.getActiveTextEditor() isnt 'undefined'
-
-    visibleTabs = @getVisibleTabKeys()
-
-    @tabs.forEach (tab, key) ->
-      tab.visibility = hasActiveEditor and visibleTabs.indexOf(key) isnt -1
-      tab.classList.remove 'first-tab'
-      tab.classList.remove 'last-tab'
-
-    if visibleTabs.length > 0
-      @tabs.get(visibleTabs[0]).classList.add 'first-tab'
-      @tabs.get(visibleTabs[visibleTabs.length - 1]).classList.add 'last-tab'
 
   # consumed in editor-linter, _renderPanel
   updateBubble: (point) ->

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -13,17 +13,17 @@ class LinterViews
     @statusTiles = []
 
     @tabs = {} # Object has methods that we need to perform certain operations, map won't be a good fit
-    @tabs['line'] = new BottomTab()
-    @tabs['file'] = new BottomTab()
-    @tabs['project'] = new BottomTab()
+    @tabs['Line'] = new BottomTab()
+    @tabs['File'] = new BottomTab()
+    @tabs['Project'] = new BottomTab()
 
     @panel = document.createElement 'div'
     @bubble = null
     @bottomStatus = new BottomStatus()
 
-    @tabs['line'].initialize 'Line', => @changeTab('line')
-    @tabs['file'].initialize 'File', => @changeTab('file')
-    @tabs['project'].initialize 'Project', => @changeTab('project')
+    @tabs['Line'].initialize 'Line', => @changeTab('line')
+    @tabs['File'].initialize 'File', => @changeTab('file')
+    @tabs['Project'].initialize 'Project', => @changeTab('project')
 
     @bottomStatus.initialize()
     @bottomStatus.addEventListener 'click', ->
@@ -86,16 +86,15 @@ class LinterViews
     @updateLineMessages()
 
     @renderPanel()
-    @tabs['file'].count = counts.file
-    @tabs['project'].count = counts.project
+    @tabs['File'].count = counts.file
+    @tabs['Project'].count = counts.project
     @bottomStatus.count = counts.project
 
   updateTabs: ->
-    visible = @getVisibleTabs()
     for key, tab of @tabs # for...of (key, value)
       tab.classList.remove('first')
       tab.classList.remove('last')
-      tab.visibility = visible.indexOf(key) isnt -1
+      tab.visibility = atom.config.get("linter.showErrorTab#{key}")
 
   # consumed in editor-linter, _renderPanel
   updateBubble: (point) ->
@@ -135,18 +134,18 @@ class LinterViews
       @messages.forEach (message) =>
         if message.currentFile and message.range?.intersectsRow @currentLine
           @lineMessages.push message
-      @tabs['line'].count = @lineMessages.length
+      @tabs['Line'].count = @lineMessages.length
 
   # This method is called when we get the status-bar service
   attachBottom: (statusBar) ->
     @statusTiles.push statusBar.addLeftTile
-      item: @tabs['line'],
+      item: @tabs['Line'],
       priority: -1002
     @statusTiles.push statusBar.addLeftTile
-      item: @tabs['file'],
+      item: @tabs['File'],
       priority: -1001
     @statusTiles.push statusBar.addLeftTile
-      item: @tabs['project'],
+      item: @tabs['Project'],
       priority: -1000
     statusIconPosition = atom.config.get('linter.statusIconPosition')
     @statusTiles.push statusBar["add#{statusIconPosition}Tile"]
@@ -172,13 +171,6 @@ class LinterViews
       @tabs.forEach (tab, key) -> tab.active = Tab is key
       @renderPanel()
     @setShowPanel @showPanel
-
-  getVisibleTabs: ->
-    toReturn = []
-    toReturn.push 'line' if atom.config.get('linter.showErrorTabLine')
-    toReturn.push 'file' if atom.config.get('linter.showErrorTabFile')
-    toReturn.push 'project' if atom.config.get('linter.showErrorTabProject')
-    toReturn
 
   removeBubble: ->
     return unless @bubble

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -10,6 +10,7 @@ class LinterViews
 
     @messages = new Set
     @markers = []
+    @lineMessages = []
     @statusTiles = []
 
     @tabs = {} # Object has methods that we need to perform certain operations, map won't be a good fit
@@ -102,7 +103,7 @@ class LinterViews
     first.classList.add('first') if first
     last.classList.add('last') if last
 
-  # consumed in editor-linter, _renderPanel
+  # consumed in editor-linter, renderPanel
   updateBubble: (point) ->
     @removeBubble()
     return unless @showBubble
@@ -202,7 +203,6 @@ class LinterViews
       Element = Message.fromMessage(message, addPath: @scope is 'Project', cloneNode: true)
       @panel.appendChild Element
     @updateBubble()
-
 
   removeMarkers: ->
     return unless @markers.length

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -36,6 +36,7 @@ class LinterViews
       tab.active = @scope is key
 
     @panel.id = 'linter-panel'
+    @updateTabs()
 
   getMessages: ->
     @messages

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -86,6 +86,7 @@ class LinterViews
 
     @updateLineMessages()
     @renderPanel()
+    @renderPanelMessages()
     @tabs['File'].count = counts.file
     @tabs['Project'].count = counts.project
     @bottomStatus.count = counts.project
@@ -135,7 +136,7 @@ class LinterViews
         if message.currentFile and message.range?.intersectsRow @currentLine
           @lineMessages.add message
       @tabs['Line'].count = @lineMessages.length
-    if shouldRender then @renderPanel()
+    if shouldRender then @renderPanelMessages()
 
   # This method is called when we get the status-bar service
   attachBottom: (statusBar) ->
@@ -162,7 +163,7 @@ class LinterViews
       @scope = Tab
       for key, tab of @tabs
         tab.active = Tab is key
-      @renderPanel()
+      @renderPanelMessages()
     @setShowPanel @showPanel
 
   removeBubble: ->

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -91,10 +91,17 @@ class LinterViews
     @bottomStatus.count = counts.project
 
   updateTabs: ->
+    first = null
+    last = null
     for key, tab of @tabs # for...of (key, value)
       tab.classList.remove('first')
       tab.classList.remove('last')
       tab.visibility = atom.config.get("linter.showErrorTab#{key}")
+      if tab.visibility
+        if first then last = tab
+        else first = tab
+    first.classList.add('first') if first
+    last.classList.add('last') if last
 
   # consumed in editor-linter, _renderPanel
   updateBubble: (point) ->

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -162,16 +162,16 @@ class LinterViews
       item: @bottomStatus,
       priority: -999
 
-  changeTab: (tab) ->
-    atom.config.set('linter.defaultErrorTab', tab)
-    @showPanel = @scope isnt tab
+  changeTab: (tabName) ->
+    atom.config.set('linter.defaultErrorTab', tabName)
+    @showPanel = @scope isnt tabName
     if not @showPanel
       for key, tab of @tabs
         tab.active = false
     else
-      @scope = tab
+      @scope = tabName
       for key, tab of @tabs
-        tab.active = tab is key
+        tab.active = tabName is key
       @renderPanelMessages()
     @setShowPanel @showPanel
 

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -161,16 +161,16 @@ class LinterViews
       item: @bottomStatus,
       priority: -999
 
-  changeTab: (Tab) ->
-    atom.config.set('linter.defaultErrorTab', Tab)
-    @showPanel = @scope isnt Tab
+  changeTab: (tab) ->
+    atom.config.set('linter.defaultErrorTab', tab)
+    @showPanel = @scope isnt tab
     if not @showPanel
       for key, tab of @tabs
         tab.active = false
     else
-      @scope = Tab
+      @scope = tab
       for key, tab of @tabs
-        tab.active = Tab is key
+        tab.active = tab is key
       @renderPanelMessages()
     @setShowPanel @showPanel
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -12,15 +12,15 @@ module.exports =
       type: 'boolean'
       default: true
     showErrorTabLine:
-      title: 'Show line tab in error panel'
+      title: 'Show Line tab in Bottom Panel'
       type: 'boolean'
       default: false
     showErrorTabFile:
-      title: 'Show file tab in error panel'
+      title: 'Show File tab in Bottom Panel'
       type: 'boolean'
       default: true
     showErrorTabProject:
-      title: 'Show project tab in error panel'
+      title: 'Show Project tab in Bottom Panel'
       type: 'boolean'
       default: true
     defaultErrorTab:

--- a/lib/views/bottom-tab.js
+++ b/lib/views/bottom-tab.js
@@ -4,6 +4,7 @@ class BottomTab extends HTMLElement{
 
   initialize(Content, onClick) {
     this._active = false
+    this._visibility = true
     this.innerHTML = Content
     this.classList.add('linter-tab')
 
@@ -20,23 +21,26 @@ class BottomTab extends HTMLElement{
     return this._active
   }
   set active(value) {
+    this._active = value
     if (value) {
       this.classList.add('active')
     } else {
       this.classList.remove('active')
     }
-    this._active = value
   }
   set count(value) {
-    this._count = value
     this.countSpan.textContent = value
   }
   set visibility(value){
+    this._visibility = value
     if(value){
       this.removeAttribute('hidden')
     } else {
       this.setAttribute('hidden', true)
     }
+  }
+  get visibility(){
+    return this._visibility
   }
 }
 

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -96,11 +96,11 @@ linter-bottom-tab {
   border: 1px solid @button-border-color;
   background: fade(@button-background-color, 33%);
   cursor: pointer;
-  &.first-tab {
+  &.first {
     border-top-left-radius: @component-border-radius;
     border-bottom-left-radius: @component-border-radius;
   }
-  &.last-tab {
+  &.last {
     margin-right: .6em;
     border-top-right-radius: @component-border-radius;
     border-bottom-right-radius: @component-border-radius;


### PR DESCRIPTION
Follow up to #637
Fixes #654
/cc @josa42 

Things that could've been avoided in that PR
 - [x] Tabs are rendered on every render event
 - [x] All the tabs are shown initially
 - [x] Codebase has some redundant methods
 - [x] Some functions are un-beautiful
 - [x] Panel workspace isn't collapsed if the scope is 'line' and there are no errors

Josa42: Thank You again for your PR :bow: , We greatly appreciate your contributions. It would've been ideal to have those issues addressed in your PR but it's still cool.

New Changes
 - [x] Fix a bug where Line Messages won't be updated if we're on a line where the errors are and save. (`LinterViews::render` doesn't provide row as an argument to `updateLineMessages`)
 - [x] FIx a bug where `removeBubble` would be called twice, once in `LinterViews::render` and once in `LinterViews::updatePanel`
 - [x] Split `updatePanel` into `updatePanelMarkers` and `updatePanelMessages`
 - [x] Don't render the whole panel along with markers when all we need is to render panel's messages :racehorse: 