### PR TITLE
Catch require time errors thrown from legacy providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * Fix a bug when Error Panel won't collapse even when there's no errors with File as Active Tab
 * Speed Improvements
-* Remove the "Default Error Tab" config option in favor of storing the currently selected tab in the package state. 
+* Remove the "Default Error Tab" config option in favor of storing the currently selected tab in the package state.
+* Fix a bug where require time errors of legacy API providers would be shown as linter errors
 
 # 1.1.0
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -51,7 +51,7 @@ module.exports =
           linter = legacy(require("#{atomPackage.path}/lib/#{implementation}"))
           @consumeLinter(linter)
         catch error
-          atom.notifications.addError "Failed to activate the #{atomPackage.metadata['name']} package", {detail: error.message + "\n" + error.stack, dismissable: true}
+          atom.notifications.addError "Failed to activate '#{atomPackage.metadata['name']}' package", {detail: error.message + "\n" + error.stack, dismissable: true}
 
   serialize: ->
     @instance.serialize()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -47,8 +47,11 @@ module.exports =
     for atomPackage in atom.packages.getLoadedPackages()
       if atomPackage.metadata['linter-package'] is true
         implementation = atomPackage.metadata['linter-implementation'] ? atomPackage.name
-        linter = legacy(require("#{atomPackage.path}/lib/#{implementation}"))
-        @consumeLinter(linter)
+        try
+          linter = legacy(require("#{atomPackage.path}/lib/#{implementation}"))
+          @consumeLinter(linter)
+        catch error
+          atom.notifications.addError "Failed to activate the #{atomPackage.metadata['name']} package", {detail: error.message + "\n" + error.stack, dismissable: true}
 
   serialize: ->
     @instance.serialize()


### PR DESCRIPTION
Ref: https://github.com/AtomLinter/Linter/issues/510