### PR TITLE
:new: Use alt-> to jump to next error

### DIFF
--- a/keymaps/linter.cson
+++ b/keymaps/linter.cson
@@ -1,3 +1,3 @@
 'atom-text-editor:not(.mini)':
   'alt': 'linter:set-bubble-transparent'
-  'alt-shift-.': 'linter:next-error'
+  'alt->': 'linter:next-error'


### PR DESCRIPTION
Also `alt-<` is not taken and easy to reach on US and german layouts. It could be used for going to the previous error, but I think that functionality was removed and has to be reimplemented.

Fixes #667 