### PR TITLE
align the status items using vertical-align: middle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Speed Improvements
 * Remove the "Default Error Tab" config option in favor of storing the currently selected tab in the package state.
 * Fix a bug where require time errors of legacy API providers would be shown as linter errors
+* Tweak the status line item positioning
 
 # 1.1.0
 

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -95,6 +95,7 @@ linter-bottom-tab {
   border: 1px solid @button-border-color;
   background: fade(@button-background-color, 33%);
   cursor: pointer;
+  vertical-align: middle;
   &.first {
     border-top-left-radius: @component-border-radius;
     border-bottom-left-radius: @component-border-radius;


### PR DESCRIPTION
- tweak the alignment of the status line tab so that they're more centered in the status line

before:

![screen shot 2015-06-29 at 7 24 06 pm](https://cloud.githubusercontent.com/assets/1269969/8433636/d4ba8a6c-1efb-11e5-9a54-3c496fbbf238.png)

after:

![screen shot 2015-06-29 at 7 24 54 pm](https://cloud.githubusercontent.com/assets/1269969/8433641/dcfe6d7e-1efb-11e5-8b12-1a0aa7202634.png)
