### PR TITLE
Changed priority of the bottom panel, fixes #668

### DIFF
--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -26,7 +26,7 @@ class LinterViews
     @bottomStatus.initialize()
     @bottomStatus.addEventListener 'click', ->
       atom.commands.dispatch atom.views.getView(atom.workspace), 'linter:next-error'
-    @panelWorkspace = atom.workspace.addBottomPanel item: @panel, visible: false
+    @panelWorkspace = atom.workspace.addBottomPanel item: @panel, visible: false, priority: 500 # priority increased because of https://github.com/AtomLinter/Linter/issues/668 
 
     for key, tab of @tabs
       do (key, tab) =>


### PR DESCRIPTION
OK, I'm trying to do my homework and to contribute more actively to this plug-in, not only asking but also giving back something! :smile: 

It seems that the problem has been addressed also by Atom guys: 
https://github.com/atom/atom/issues/4834

they added [a note in workspace.coffee](https://github.com/atom/atom/blob/f73d3df2339bd2ec6017e156dbc5edadf2b9c18b/src/workspace.coffee#L670) that says:

> If your panel changes its size throughout its lifetime, consider giving it a higher
  priority, allowing fixed size panels to be closer to the edge. This allows control targets to
  remain more static for easier targeting by users that employ mice or trackpads.

Attached you'll find a PR with the change.