### PR TITLE
add go to previous error

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     }
   },
   "dependencies": {
+    "double-ended-queue": "^2.1.0-0",
     "temp": "^0.8.3",
     "xregexp": "^2.0.0"
   }


### PR DESCRIPTION
This is done by replacing the Set that was used to hold the errors and warnings with a double ended queue (deque). An Array could have been used but the deque has two main advantages that justify the extra dependency (which is btw tiny, 230 loc):

1. It can be cleared in a performant way
  Creating a new array would have the downsides that the commands instance would hold a reference to the old array

  Splicing the array might shrink it (who knows what v8 might eventually do, also see https://code.google.com/p/v8/issues/detail?id=2131). The deque does not shrink, which might sound awful but all references are [cleared] (https://github.com/petkaantonov/deque/blob/master/src/deque.js#L173) which allows garbage collection to kick in, also if we assume that warnings and errors appear one at a time and disappear one at a time, then shrinking the data store is quite a useless operation.

2. Handling negative indexes is way easier since this deque-implementation supports them