### PR TITLE
Create Helpers for Easy CLI Linter Creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Speed Improvements
 * Remove the "Default Error Tab" config option in favor of storing the currently selected tab in the package state.
 * Fix a bug where require time errors of legacy API providers would be shown as linter errors
+* Added Helpers which aid the creation of Command Line Linters.
 
 # 1.1.0
 

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -82,8 +82,10 @@ class EditorLinter
 
       return unless scopes.some (entry) -> entry in linter.grammarScopes
 
+      helpers = require('./helpers')
+
       Promises.push new Promise((resolve) =>
-        resolve(linter.lint(@editor))
+        resolve(linter.lint(@editor, helpers))
       ).then((results) =>
         if linter.scope is 'project'
           @linter.setProjectMessages(linter, results)

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -40,6 +40,6 @@ module.exports = Helpers =
     throw new Error "No File Path to work with." if not filePath
     path = require 'path'
     return new Promise (resolve, reject) ->
-      file = path.baseName(filePath)
-      options.cwd = path.baseDir(filePath) if not options.cwd
-      resolve(exec("#{command} #{file}"), options)
+      file = path.basename(filePath)
+      options.cwd = path.dirname(filePath) if not options.cwd
+      resolve(Helpers.exec("#{command} #{file}"), options)

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -41,7 +41,6 @@ module.exports = Helpers =
       else
         process.stdout.on 'data', (d) -> data.push(d.toString())
       process.on 'close', ->
-        console.log data
         resolve(data)
 
   # This should only be used if the linter is only working with files in their
@@ -50,17 +49,9 @@ module.exports = Helpers =
     throw new Error "Nothing to execute." if not arguments.length
     throw new Error "No File Path to work with." if not filePath
     return new Promise (resolve, reject) ->
-      file = path.basename(filePath)
       options.cwd = path.dirname(filePath) if not options.cwd
       command = "#{command} #{filePath}"
-      process = child_process.exec(command, options)
-      data = []
-      if options.stream == 'stderr'
-        process.stderr.on 'data', (d) -> data.push(d.toString())
-      else
-        process.stdout.on 'data', (d) -> data.push(d.toString())
-      process.on 'close', ->
-        resolve(data)
+      resolve(Helpers.exec(command, options))
 
   # Due to what we are attempting to do, the only viable solution right now is
   #   XRegExp.

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -36,12 +36,12 @@ module.exports = Helpers =
     return new Promise (resolve, reject) ->
       process = child_process.exec(command, options)
       options.stream = 'stdout' if not options.stream
-      data = []
-      if options.stream == 'stderr'
-        process.stderr.on 'data', (d) -> data.push(d.toString())
-      else
-        process.stdout.on 'data', (d) -> data.push(d.toString())
+      data = ['']
+      process.stdout.on 'data', (d) -> data.push(d.toString()) if options.stream == 'stdout'
+      process.stderr.on 'data', (d) -> data.push(d.toString()) if options.stream == 'stderr'
       process.stdin.write(options.stdin.toString()) if options.stdin
+      process.on 'error', (err) ->
+        reject(err)
       process.on 'close', ->
         resolve(data)
 
@@ -77,8 +77,8 @@ module.exports = Helpers =
       toReturn = []
       regex = XRegExp(regex)
       for line in data
-        if regex.test line
-          match = XRegExp.exec(line, regex)
+        match = XRegExp.exec(line, regex)
+        if match
           options.baseReduction = 1 if not options.baseReduction
           lineStart = 0
           lineStart = match.line - options.baseReduction if match.line

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -36,7 +36,7 @@ module.exports = Helpers =
     return new Promise (resolve, reject) ->
       process = child_process.exec(command, options)
       options.stream = 'stdout' if not options.stream
-      data = ['']
+      data = []
       process.stdout.on 'data', (d) -> data.push(d.toString()) if options.stream == 'stdout'
       process.stderr.on 'data', (d) -> data.push(d.toString()) if options.stream == 'stderr'
       process.stdin.write(options.stdin.toString()) if options.stdin

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -31,10 +31,10 @@ module.exports = Helpers =
   # Everything past this point relates to CLI helpers as loosly demoed out in:
   #   https://gist.github.com/steelbrain/43d9c38208bf9f2964ab
 
-  exec: (command, options = {stream: 'stdout'}) ->
+  exec: (command, args = [], options = {stream: 'stdout'}) ->
     throw new Error "Nothing to execute." if not arguments.length
     return new Promise (resolve, reject) ->
-      process = child_process.exec(command, options)
+      process = child_process.spawn(command, args, options)
       options.stream = 'stdout' if not options.stream
       data = []
       process.stdout.on 'data', (d) -> data.push(d.toString()) if options.stream == 'stdout'
@@ -47,13 +47,13 @@ module.exports = Helpers =
 
   # This should only be used if the linter is only working with files in their
   #   base directory. Else wise they should use `Helpers#exec`.
-  execFilePath: (command, filePath, options = {}) ->
+  execFilePath: (command, args = [], filePath, options = {}) ->
     throw new Error "Nothing to execute." if not arguments.length
     throw new Error "No File Path to work with." if not filePath
     return new Promise (resolve, reject) ->
       options.cwd = path.dirname(filePath) if not options.cwd
-      command = "#{command} #{filePath}"
-      resolve(Helpers.exec(command, options))
+      args.push(filePath)
+      resolve(Helpers.exec(command, args, options))
 
   # Due to what we are attempting to do, the only viable solution right now is
   #   XRegExp.

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -1,6 +1,8 @@
 {Range} = require('atom')
 
-Helpers = module.exports =
+module.exports = Helpers =
+  # Validates that the results passed to Linter Base by a Provider contain the
+  #   information needed to display an issue.
   validateResults: (results) ->
     if (not results) or results.constructor.name isnt 'Array'
       throw new Error "Got invalid response from Linter, Type: #{typeof results}"
@@ -11,17 +13,14 @@ Helpers = module.exports =
       result.class = result.type.toLowerCase().replace(' ', '-')
       Helpers.validateResults(result.trace) if result.trace
     results
+
+  # Validates that a provider is capable of providing the Base Linter info
+  #   needed to be used at lint time.
   validateLinter: (linter) ->
     unless linter.grammarScopes instanceof Array
-      message = "grammarScopes is not an Array. (see console for more info)"
-      console.warn(message)
-      console.warn('grammarScopes', linter.grammarScopes)
-      throw new Error(message)
-
+      throw new Error("grammarScopes is not an Array. Got: #{linter.grammarScopes})")
     unless linter.lint?
       throw new Error("Missing linter.lint")
-
     if typeof linter.lint isnt 'function'
       throw new Error("linter.lint isn't a function")
-
     return true

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -76,19 +76,44 @@ module.exports = Helpers =
   #      closest matching syntax element based on your code syntax (optional)
   # colStart: column to on which to start a higlight (optional)
   # colEnd: column to end highlight (optional)
-  parse: (data, regex) ->
+  # We place priority on `lineStart` and `lineEnd` over `line.`
+  # We place priority on `colStart` and `colEnd` over `col.`
+  parse: (data, regex, options = {baseReduction: 1}) ->
     XRegExp = require('xregexp').XRegExp
     new Promise (resolve, reject) ->
       toReturn = []
       regex = XRegExp(regex)
       for line in data
         match = XRegExp.exec(line, regex)
-        console.log match
         if match
+          if match.lineStart
+            lineStart = match.lineStart - options.baseReduction
+          else if match.line
+            lineStart = match.line - options.baseReduction
+          else
+            lineStart = 0
+          if match.colStart
+            colStart = match.colStart - options.baseReduction
+          else if match.col
+            colStart = match.col - options.baseReduction
+          else
+            colStart = 0
+          if match.lineEnd
+            lineEnd = match.lineEnd - options.baseReduction
+          else if match.line
+            lineEnd = match.line - options.baseReduction
+          else
+            lineEnd = 0
+          if match.colEnd
+            colEnd = match.colEnd - options.baseReduction
+          else if match.col
+            colEnd = match.col - options.baseReduction
+          else
+            colEnd = 0
           toReturn.push(
             type: match.type,
             text: match.message,
             filePath: match.file
-            range: [[match.line - 1, 0], [match.line - 1, 0]]
+            range: [[lineStart, colStart], [lineEnd, colEnd]]
           )
       resolve(toReturn)

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -1,3 +1,8 @@
+{Range} = require('atom')
+XRegExp = require('xregexp').XRegExp
+path = require 'path'
+child_process = require 'child_process'
+
 module.exports = Helpers =
   # Validates that the results passed to Linter Base by a Provider contain the
   #   information needed to display an issue.
@@ -7,7 +12,6 @@ module.exports = Helpers =
     for result in results
       unless result.type
         throw new Error "Missing type field on Linter Response, Got: #{Object.keys(result)}"
-      {Range} = require('atom')
       result.range = Range.fromObject result.range if result.range?
       result.class = result.type.toLowerCase().replace(' ', '-')
       Helpers.validateResults(result.trace) if result.trace
@@ -29,7 +33,6 @@ module.exports = Helpers =
 
   exec: (command, options = {stream: 'stdout'}) ->
     throw new Error "Nothing to execute." if not arguments.length
-    child_process = require 'child_process'
     return new Promise (resolve, reject) ->
       process = child_process.exec(command, options)
       data = []
@@ -46,8 +49,6 @@ module.exports = Helpers =
   execFilePath: (command, filePath, options = {}) ->
     throw new Error "Nothing to execute." if not arguments.length
     throw new Error "No File Path to work with." if not filePath
-    path = require 'path'
-    child_process = require 'child_process'
     return new Promise (resolve, reject) ->
       file = path.basename(filePath)
       options.cwd = path.dirname(filePath) if not options.cwd
@@ -79,7 +80,6 @@ module.exports = Helpers =
   # We place priority on `lineStart` and `lineEnd` over `line.`
   # We place priority on `colStart` and `colEnd` over `col.`
   parse: (data, regex, options = {baseReduction: 1}) ->
-    XRegExp = require('xregexp').XRegExp
     new Promise (resolve, reject) ->
       toReturn = []
       regex = XRegExp(regex)

--- a/spec/fixtures/test.txt
+++ b/spec/fixtures/test.txt
@@ -1,0 +1,1 @@
+This is a test.

--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -38,11 +38,12 @@ describe "The Linter Validation Helper", ->
     expect(Helpers.validateLinter(linter)).toEqual(true)
 
 describe "The Command Execution Helper", ->
-  beforeEach ->
-    waitsForPromise ->
-      @command = Helpers.exec('echo')
   it "should throw when no parameters are passed.", ->
     expect( -> Helpers.exec()).toThrow()
+  it "should return the results when successful.", ->
+    Helpers.exec("echo 'Test'").then (output) ->
+      expect(output).toEqual(['Test\n'])
+
 
 describe "The Command and FilePath Helper", ->
   it "should throw when no parametes are passed.", ->

--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -50,3 +50,8 @@ describe "The Command and FilePath Helper", ->
     expect( -> Helpers.execFilePath()).toThrow()
   it "should throw when no File Path is passed.", ->
     expect( -> Helpers.execFilePath('echo')).toThrow()
+  it "should return results when successful.", ->
+    waitsForPromise -> atom.workspace.open 'test.txt'
+    atom.workspace.observeTextEditors (editor) ->
+      Helpers.execFilePath('cat', [], editor.getPath()).then (output) ->
+        expect(output).toEqual(['This is a test.\n'])

--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -36,3 +36,16 @@ describe "The Linter Validation Helper", ->
       lint: ->
     }
     expect(Helpers.validateLinter(linter)).toEqual(true)
+
+describe "The Command Execution Helper", ->
+  beforeEach ->
+    waitsForPromise ->
+      @command = Helpers.exec('echo')
+  it "should throw when no parameters are passed.", ->
+    expect( -> Helpers.exec()).toThrow()
+
+describe "The Command and FilePath Helper", ->
+  it "should throw when no parametes are passed.", ->
+    expect( -> Helpers.execFilePath()).toThrow()
+  it "should throw when no File Path is passed.", ->
+    expect( -> Helpers.execFilePath('echo')).toThrow()

--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -55,3 +55,16 @@ describe "The Command and FilePath Helper", ->
     atom.workspace.observeTextEditors (editor) ->
       Helpers.execFilePath('cat', [], editor.getPath()).then (output) ->
         expect(output).toEqual(['This is a test.\n'])
+
+  describe "The Regex Parsing Helper", ->
+    it "should return Linter results when successful.", ->
+      regex = 'type:(?<type>.+) message:(?<message>.+)'
+      input = ['type:type message:message']
+      output = [(
+        type: 'type'
+        text: 'message'
+        filePath: undefined
+        range: [[0, 0], [0, 0]]
+      )]
+      Helpers.parse(input, regex).then (results) ->
+        expect(results).toEqual(output)


### PR DESCRIPTION
I'm not done with this yet. But it's time for this to have some exposure.

I've created a `linter-ruby` example, which I might just merge into `linter-ruby` later.
```coffee
module.exports = LinterRuby =
  config:
    rubyExecutablePath:
      default: 'ruby'
      type: 'string'

  activate: ->
    # Show the user an error if they do not have an appropriate linter based
    #   package installed from Atom Package Manager. This will not be an issue
    #   after a base linter package is integrated into Atom, in the coming
    #   months.
    # TODO: Remove when Linter Base is integrated into Atom.
    atom.notifications.addError(
      'Linter package not found.',
      {
        detail: 'Please install the `linter` package in your Settings view'
      }
    ) unless atom.packages.getLoadedPackages 'linter'

  provideLinter: ->
    regex = '(?<file>.+):(?<line>\\d+):\\s(?<type>(?:\\w+(?:\\s)?)(?:error|warning))(?:,\\s)?(?<message>.+)'
    command = "#{atom.config.get('linter-ruby.rubyExecutablePath')} -wc"
    provider =
      scope: 'file'
      lintOnFly: false
      grammarScopes: ['source.ruby', 'source.ruby.rails', 'source.ruby.rspec']
      lint: (activeEditor, helpers) ->
        file = activeEditor.getPath()
        helpers.execFilePath(command, file, {stream: 'stderr'}).then (output) ->
          helpers.parse(output, regex)
```

It works:
![screen shot 2015-07-02 at 3 42 21 pm](https://cloud.githubusercontent.com/assets/594124/8488599/ff007f80-20d0-11e5-8cd7-4aef10da13c3.png)

Should be merged in before #676 
