### PR TITLE
prevent badge overflow

### DIFF
--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -130,6 +130,8 @@ atom-text-editor::shadow .linter-highlight .icon-right{
 atom-text-editor::shadow .linter-highlight, .linter-highlight{
   &.badge {
     border-radius: @component-border-radius;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   &.error {
     &:not(.line-number){


### PR DESCRIPTION
Badges in the tooltips overflow outside their colored box. This at least prevents that, but perhaps it could be improved further by making sure the badge grows with its content.

![before](https://cloud.githubusercontent.com/assets/2543659/8504113/619ac3ee-21cb-11e5-82fe-c07385180d59.png)

![after](https://cloud.githubusercontent.com/assets/2543659/8504116/63ccbef6-21cb-11e5-8640-78cc960c13eb.png)
