### PR TITLE
Support buffer modifying linters

### DIFF
--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -65,8 +65,8 @@ class EditorLinter
       return if linter.modifiesBuffer isnt bufferModifying
       return unless Helpers.shouldTriggerLinter(linter, wasTriggeredOnChange, scopes)
       currentLinter = =>
-        return Promise.resolve().then( =>
-          return linter.lint(@editor, Helpers)
+        return new Promise((resolve) =>
+          resolve(linter.lint(@editor, Helpers))
         ).then((results) =>
           if linter.scope is 'project'
             @linter.setMessages(linter, results)

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -66,7 +66,12 @@ class EditorLinter
       Promises.push new Promise((resolve) =>
         resolve(linter.lint(@editor, Helpers))
       ).then((results) =>
-        @gotLinterResults(linter, results)
+        if linter.scope is 'project'
+          @linter.setMessages(linter, results)
+        else
+          # Trigger event instead of updating on purpose, because
+          # we want to make MessageRegistry the central message repo
+          @emitter.emit('should-update', {linter, results})
       ).catch (error) ->
         atom.notifications.addError error.message, {detail: error.stack, dismissable: true}
     Promises

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -60,11 +60,7 @@ class EditorLinter
 
   # This method returns an array of promises to be used in lint
   triggerLinters: (bufferModifying, wasTriggeredOnChange, scopes) ->
-    ToReturn =
-      if bufferModifying
-        Promise.resolve()
-      else
-        []
+    ToReturn = if bufferModifying then Promise.resolve() else []
     @linter.getLinters().forEach (linter) =>
       return if linter.modifiesBuffer isnt bufferModifying
       return unless Helpers.shouldTriggerLinter(linter, wasTriggeredOnChange, scopes)

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -66,8 +66,9 @@ class EditorLinter
       else
         []
     @linter.getLinters().forEach (linter) =>
+      return if linter.modifiesBuffer isnt bufferModifying
       return unless Helpers.shouldTriggerLinter(linter, wasTriggeredOnChange, scopes)
-      currentLinter =>
+      currentLinter = =>
         return Promise.resolve().then( =>
           return linter.lint(@editor, Helpers)
         ).then((results) =>
@@ -83,7 +84,7 @@ class EditorLinter
         ToReturn.then -> currentLinter()
       else
         ToReturn.push(currentLinter())
-    Promises
+    ToReturn
 
   # This method sets or gets the lock status of given type
   lock: (wasTriggeredOnChange, value) ->

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -61,9 +61,7 @@ class EditorLinter
   triggerLinters: (wasTriggeredOnChange, scopes) ->
     Promises = []
     @linter.getLinters().forEach (linter) =>
-      # Trigger fly linters on save, but not save linters on fly
-      return if wasTriggeredOnChange and not linter.lintOnFly
-      return unless scopes.some (entry) -> entry in linter.grammarScopes
+      return unless Helpers.shouldTriggerLinter(linter, wasTriggeredOnChange, scopes)
       Promises.push new Promise((resolve) =>
         resolve(linter.lint(@editor, Helpers))
       ).then((results) =>

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -4,6 +4,12 @@ path = require 'path'
 child_process = require 'child_process'
 
 Helpers = module.exports =
+  shouldTriggerLinter: (linter, wasTriggeredOnChange, scopes)->
+    # Trigger fly linters on save, but not save linters on fly
+    return false if wasTriggeredOnChange and not linter.lintOnFly
+    return false unless scopes.some (entry) -> entry in linter.grammarScopes
+    return true
+
   validateMessages: (results) ->
     if (not results) or results.constructor.name isnt 'Array'
       throw new Error "Got invalid response from Linter, Type: #{typeof results}"

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -27,6 +27,7 @@ Helpers = module.exports =
       throw new Error("Missing linter.lint")
     if typeof linter.lint isnt 'function'
       throw new Error("linter.lint isn't a function")
+    linter.modifiesBuffer = Boolean(linter.modifiesBuffer)
     return true
 
   # Everything past this point relates to CLI helpers as loosly demoed out in:

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -6,6 +6,8 @@ child_process = require 'child_process'
 Helpers = module.exports =
   shouldTriggerLinter: (linter, wasTriggeredOnChange, scopes)->
     # Trigger fly linters on save, but not save linters on fly
+    # Because we want to trigger onFly linters on save when the
+    # user has disabled lintOnFly from config
     return false if wasTriggeredOnChange and not linter.lintOnFly
     return false unless scopes.some (entry) -> entry in linter.grammarScopes
     return true

--- a/spec/buffer-modifying-provider-spec.coffee
+++ b/spec/buffer-modifying-provider-spec.coffee
@@ -2,10 +2,6 @@ describe 'buffer modifying linters', ->
   getModuleMain = -> atom.packages.getActivePackage('linter').mainModule.instance
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage('status-bar')
-      .catch (err)->
-        console.log err
-    waitsForPromise ->
       atom.packages.activatePackage('linter')
     waitsForPromise ->
       atom.workspace.open('test.txt')

--- a/spec/buffer-modifying-provider-spec.coffee
+++ b/spec/buffer-modifying-provider-spec.coffee
@@ -29,16 +29,14 @@ describe 'buffer modifying linter', ->
       linter.getActiveEditorLinter().lint(false).then ->
         expect(last).toBe('normal')
   it 'runs in sequence', ->
-    activeEditor = atom.workspace.getActiveTextEditor()
-    wasTriggered = false
+    exeOrder = []
     first =
       grammarScopes: ['*']
       scope: 'file'
       lintOnFly: false
       modifiesBuffer: true
       lint: ->
-        wasTriggered = true
-        activeEditor.setText('first')
+        exeOrder.push('first')
         return []
     second =
       grammarScopes: ['*']
@@ -46,8 +44,7 @@ describe 'buffer modifying linter', ->
       lintOnFly: false
       modifiesBuffer: true
       lint: ->
-        expect(activeEditor.getText()).toBe('first')
-        activeEditor.setText('second')
+        exeOrder.push('second')
         return []
     third =
       grammarScopes: ['*']
@@ -55,8 +52,7 @@ describe 'buffer modifying linter', ->
       lintOnFly: false
       modifiesBuffer: true
       lint: ->
-        expect(activeEditor.getText()).toBe('second')
-        activeEditor.setText('third')
+        exeOrder.push('third')
         return []
     normalLinter =
       grammarScopes: ['*']
@@ -64,7 +60,7 @@ describe 'buffer modifying linter', ->
       lintOnFly: false
       modifiesBuffer: false
       lint: ->
-        expect(activeEditor.getText()).toBe('third')
+        exeOrder.push('forth')
         return []
     linter.addLinter(first)
     linter.addLinter(second)
@@ -72,4 +68,7 @@ describe 'buffer modifying linter', ->
     linter.addLinter(normalLinter)
     waitsForPromise ->
       linter.getActiveEditorLinter().lint(false).then ->
-        expect(wasTriggered).toBe(true)
+        expect(exeOrder[0]).toBe('first')
+        expect(exeOrder[1]).toBe('second')
+        expect(exeOrder[2]).toBe('third')
+        expect(exeOrder[3]).toBe('forth')

--- a/spec/buffer-modifying-provider-spec.coffee
+++ b/spec/buffer-modifying-provider-spec.coffee
@@ -1,12 +1,11 @@
 describe 'buffer modifying linter', ->
-  getModuleMain = -> atom.packages.getActivePackage('linter').mainModule.instance
+  linter = null
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage('linter')
+      atom.packages.activatePackage('linter').then (pack) -> linter = pack.mainModule.instance
     waitsForPromise ->
       atom.workspace.open('test.txt')
   it 'triggers before other linters', ->
-    linter = getModuleMain()
     last = null
     bufferModifying =
       grammarScopes: ['*']
@@ -30,7 +29,6 @@ describe 'buffer modifying linter', ->
       linter.getActiveEditorLinter().lint(false).then ->
         expect(last).toBe('normal')
   it 'runs in sequence', ->
-    linter = getModuleMain()
     activeEditor = atom.workspace.getActiveTextEditor()
     wasTriggered = false
     first =

--- a/spec/buffer-modifying-provider-spec.coffee
+++ b/spec/buffer-modifying-provider-spec.coffee
@@ -8,7 +8,7 @@ describe 'buffer modifying linters', ->
     waitsForPromise ->
       atom.packages.activatePackage('linter')
     waitsForPromise ->
-      atom.workspace.open(__dirname + '/fixtures/test.txt')
+      atom.workspace.open('test.txt')
   it 'is triggered before other linters', ->
     linter = getModuleMain()
     last = null

--- a/spec/buffer-modifying-provider-spec.coffee
+++ b/spec/buffer-modifying-provider-spec.coffee
@@ -1,0 +1,35 @@
+describe 'buffer modifying linters', ->
+  getModuleMain = -> atom.packages.getActivePackage('linter').mainModule.instance
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage('status-bar')
+      .catch (err)->
+        console.log err
+    waitsForPromise ->
+      atom.packages.activatePackage('linter')
+    waitsForPromise ->
+      atom.workspace.open(__dirname + '/fixtures/test.txt')
+  it 'is triggered before other linters', ->
+    linter = getModuleMain()
+    last = null
+    normalLinter =
+      grammarScopes: ['*']
+      scope: 'file'
+      lintOnFly: false
+      modifiesBuffer: false
+      lint: ->
+        last = 'normal'
+        return []
+    bufferModifying =
+      grammarScopes: ['*']
+      scope: 'file'
+      lintOnFly: false
+      modifiesBuffer: true
+      lint: ->
+        last = 'bufferModifying'
+        return []
+    linter.addLinter(normalLinter)
+    linter.addLinter(bufferModifying)
+    waitsForPromise ->
+      linter.getActiveEditorLinter().lint(false).then ->
+        expect(last).toBe('normal')

--- a/spec/buffer-modifying-provider-spec.coffee
+++ b/spec/buffer-modifying-provider-spec.coffee
@@ -1,11 +1,11 @@
-describe 'buffer modifying linters', ->
+describe 'buffer modifying linter', ->
   getModuleMain = -> atom.packages.getActivePackage('linter').mainModule.instance
   beforeEach ->
     waitsForPromise ->
       atom.packages.activatePackage('linter')
     waitsForPromise ->
       atom.workspace.open('test.txt')
-  it 'are triggered before other linters', ->
+  it 'triggers before other linters', ->
     linter = getModuleMain()
     last = null
     bufferModifying =
@@ -29,7 +29,7 @@ describe 'buffer modifying linters', ->
     waitsForPromise ->
       linter.getActiveEditorLinter().lint(false).then ->
         expect(last).toBe('normal')
-  it 'run in sequence', ->
+  it 'runs in sequence', ->
     linter = getModuleMain()
     activeEditor = atom.workspace.getActiveTextEditor()
     wasTriggered = false

--- a/spec/buffer-modifying-provider-spec.coffee
+++ b/spec/buffer-modifying-provider-spec.coffee
@@ -5,7 +5,7 @@ describe 'buffer modifying linters', ->
       atom.packages.activatePackage('linter')
     waitsForPromise ->
       atom.workspace.open('test.txt')
-  it 'is triggered before other linters', ->
+  it 'are triggered before other linters', ->
     linter = getModuleMain()
     last = null
     bufferModifying =
@@ -29,7 +29,7 @@ describe 'buffer modifying linters', ->
     waitsForPromise ->
       linter.getActiveEditorLinter().lint(false).then ->
         expect(last).toBe('normal')
-  it 'runs in sequence', ->
+  it 'run in sequence', ->
     linter = getModuleMain()
     activeEditor = atom.workspace.getActiveTextEditor()
     wasTriggered = false

--- a/spec/buffer-modifying-provider-spec.coffee
+++ b/spec/buffer-modifying-provider-spec.coffee
@@ -29,7 +29,7 @@ describe 'buffer modifying linters', ->
     waitsForPromise ->
       linter.getActiveEditorLinter().lint(false).then ->
         expect(last).toBe('normal')
-  it 'runs in parallel', ->
+  it 'runs in sequence', ->
     linter = getModuleMain()
     activeEditor = atom.workspace.getActiveTextEditor()
     wasTriggered = false


### PR DESCRIPTION
Fixes https://github.com/AtomLinter/Linter/issues/696
I've confirmed that it works.
Buffer modifying linters need to have a `modifiesBuffer:true` in their object. This change is backward compatible.