### PR TITLE
Fix bubble marker leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Upcoming
 
+* Fixed a marker leak with bubbles, which would make editor slower over time.
 * Remove an oudated config (`statusIconPosition`).
 
 # 1.2.3

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -57,13 +57,11 @@ class LinterViews
     point = point || activeEditor.getCursorBufferPosition()
     for message in @messagesLine
       continue unless message.range?.containsPoint point
-      @bubble = activeEditor.decorateMarker(
-        activeEditor.markBufferRange([point, point], {invalidate: 'never'})
-        {
-          type: 'overlay',
-          position: 'tail',
-          item: @renderBubbleContent(message)
-        }
+      @bubble = activeEditor.markBufferRange([point, point], {invalidate: 'inside'})
+      activeEditor.decorateMarker(@bubble,
+        type: 'overlay',
+        position: 'tail',
+        item: @renderBubbleContent(message)
       )
       break
 


### PR DESCRIPTION
Just like the title says. We were leaking a marker, that would slow the text editor over time.
Ref: #708